### PR TITLE
Refactor cleanup of libs, use to cleanup iolib

### DIFF
--- a/examples/embed/main.go
+++ b/examples/embed/main.go
@@ -25,5 +25,5 @@ func main() {
 	sum, _ := rt.Call1(r.MainThread(), add, rt.IntValue(40), rt.IntValue(2))
 
 	// --> 42
-	fmt.Println(sum)
+	fmt.Println(sum.AsInt())
 }

--- a/examples/embed/main_test.go
+++ b/examples/embed/main_test.go
@@ -1,0 +1,6 @@
+package main
+
+func Example_main() {
+	main()
+	// Output: 42
+}

--- a/examples/extend/main_test.go
+++ b/examples/extend/main_test.go
@@ -1,0 +1,6 @@
+package main
+
+func Example_main() {
+	main()
+	// Output: hello	42
+}

--- a/examples/userdata/main.go
+++ b/examples/userdata/main.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/arnodel/golua/examples/userdata/regexlib"
+	"github.com/arnodel/golua/lib"
 	"github.com/arnodel/golua/lib/base"
 	"github.com/arnodel/golua/lib/packagelib"
 	rt "github.com/arnodel/golua/runtime"
@@ -18,10 +19,13 @@ print("found:", match)
 `
 
 func main() {
-	r := rt.New(os.Stdout)      // Create runtime
-	base.Load(r)                // Load base lib (needed for print)
-	packagelib.LibLoader.Run(r) // Load package lib (needed for require)
-	regexlib.LibLoader.Run(r)   // Load our example lib
+	r := rt.New(os.Stdout) // Create runtime
+	lib.LoadLibs(
+		r,
+		base.LibLoader,       // Load base lib (needed for print)
+		packagelib.LibLoader, // Load package lib (needed for require)
+		regexlib.LibLoader,   // Load our example lib
+	)
 
 	// Now compile and run the lua code
 	chunk, _ := r.CompileAndLoadLuaChunk("test", []byte(code), rt.TableValue(r.GlobalEnv()))

--- a/examples/userdata/main_test.go
+++ b/examples/userdata/main_test.go
@@ -1,0 +1,8 @@
+package main
+
+func Example_main() {
+	main()
+	// Output:
+	// ptn:	regex("[0-9]+")
+	// found:	123
+}

--- a/examples/userdata/regexlib/regexlib.go
+++ b/examples/userdata/regexlib/regexlib.go
@@ -30,7 +30,7 @@ var LibLoader = packagelib.Loader{
 
 // This function is the Load function of the LibLoader defined above.  It sets
 // up a package (which is a lua table and returns it).
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	// First build a table of methods.
 	regexMethods := rt.NewTable()
 	r.SetEnvGoFunc(regexMethods, "find", regexFind, 2, false)
@@ -48,7 +48,7 @@ func load(r *rt.Runtime) rt.Value {
 	r.SetEnvGoFunc(pkg, "new", newRegex, 1, false)
 
 	// Return the package table
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 // Creates a new regex userdata from a string.

--- a/lib/base/base.go
+++ b/lib/base/base.go
@@ -6,11 +6,16 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/arnodel/golua/lib/packagelib"
 	rt "github.com/arnodel/golua/runtime"
 	"github.com/arnodel/golua/safeio"
 )
 
-func Load(r *rt.Runtime) {
+var LibLoader = packagelib.Loader{
+	Load: Load,
+}
+
+func Load(r *rt.Runtime) (rt.Value, func()) {
 	env := r.GlobalEnv()
 	r.SetEnv(env, "_G", rt.TableValue(env))
 	r.SetEnv(env, "_VERSION", rt.StringValue("Golua 5.3"))
@@ -47,7 +52,7 @@ func Load(r *rt.Runtime) {
 	)
 	// That's not safe!
 	r.SetEnvGoFunc(env, "collectgarbage", collectgarbage, 2, false)
-
+	return rt.NilValue, nil
 }
 
 func ToString(t *rt.Thread, v rt.Value) (string, *rt.Error) {

--- a/lib/coroutine/coroutine.go
+++ b/lib/coroutine/coroutine.go
@@ -11,7 +11,7 @@ var LibLoader = packagelib.Loader{
 	Name: "coroutine",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 
 	rt.SolemnlyDeclareCompliance(
@@ -26,7 +26,7 @@ func load(r *rt.Runtime) rt.Value {
 		r.SetEnvGoFunc(pkg, "yield", yield, 0, true),
 	)
 
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 func create(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/debuglib/debuglib.go
+++ b/lib/debuglib/debuglib.go
@@ -13,7 +13,7 @@ var LibLoader = packagelib.Loader{
 	Name: "debug",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 	pkgVal := rt.TableValue(pkg)
 	r.SetEnv(r.GlobalEnv(), "debug", pkgVal)
@@ -32,7 +32,7 @@ func load(r *rt.Runtime) rt.Value {
 		r.SetEnvGoFunc(pkg, "upvalueid", upvalueid, 2, false),
 	)
 
-	return pkgVal
+	return pkgVal, nil
 }
 
 func getinfo(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/golib/golib.go
+++ b/lib/golib/golib.go
@@ -22,7 +22,7 @@ type govalueKeyType struct{}
 // TODO: a better value?
 var govalueKey = rt.AsValue(govalueKeyType{})
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 	r.SetEnvGoFunc(pkg, "import", goimport, 1, false)
 
@@ -34,7 +34,7 @@ func load(r *rt.Runtime) rt.Value {
 
 	r.SetRegistry(govalueKey, rt.TableValue(meta))
 
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 func getMeta(r *rt.Runtime) *rt.Table {

--- a/lib/iolib/file.go
+++ b/lib/iolib/file.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"strings"
 
 	rt "github.com/arnodel/golua/runtime"
@@ -50,7 +51,7 @@ func NewFile(file *os.File, options int) *File {
 	} else {
 		f.writer = &nobufWriter{file}
 	}
-	currentFiles[f] = struct{}{}
+	runtime.SetFinalizer(f, (*File).cleanup)
 	return f
 }
 
@@ -288,35 +289,12 @@ func (f *File) Name() string {
 	return f.file.Name()
 }
 
-func (f *File) release() {
-	delete(currentFiles, f)
-	f.cleanup()
-}
-
+// Best effort to flush and close files when they are no longer accessible.
 func (f *File) cleanup() {
+	if !f.closed {
+		f.Close()
+	}
 	if f.temp {
 		_ = os.Remove(f.Name())
 	}
-}
-
-//
-// Current files - TODO: refactor this
-//
-
-var currentFiles = map[*File]struct{}{}
-
-func cleanupCurrentFiles() {
-	// We don't want to close the std files, that breaks testing.  In normal
-	// operation it's the end of the program so that' OK too.
-	for f := range currentFiles {
-		switch f.file {
-		case os.Stdout, os.Stderr:
-			f.Flush()
-		case os.Stdin:
-			// Nothing to do?
-		default:
-			f.cleanup()
-		}
-	}
-	currentFiles = map[*File]struct{}{}
 }

--- a/lib/iolib/file.go
+++ b/lib/iolib/file.go
@@ -133,6 +133,7 @@ func (f *File) Close() error {
 		}
 	}
 	if f.closed {
+		// Also this is undocumented, in this case an error is returned
 		return errFileAlreadyClosed
 	}
 	f.closed = true

--- a/lib/iolib/iolib.go
+++ b/lib/iolib/iolib.go
@@ -33,7 +33,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 		r.SetEnvGoFunc(methods, "close", fileclose, 1, false),
 		r.SetEnvGoFunc(methods, "flush", fileflush, 1, false),
 		r.SetEnvGoFunc(methods, "seek", fileseek, 3, false),
-		r.SetEnvGoFunc(methods, "setvbuf", filesetvbuf, 2, false),
+		r.SetEnvGoFunc(methods, "setvbuf", filesetvbuf, 3, false),
 		// TODO: setvbuf,
 		r.SetEnvGoFunc(methods, "write", filewrite, 1, true),
 	)

--- a/lib/iolib/iolib.go
+++ b/lib/iolib/iolib.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"runtime"
 
 	"github.com/arnodel/golua/lib/packagelib"
 	rt "github.com/arnodel/golua/runtime"
@@ -19,12 +18,11 @@ var ioKey = rt.AsValue(ioKeyType{})
 
 // LibLoader can load the io lib.
 var LibLoader = packagelib.Loader{
-	Load:    load,
-	Name:    "io",
-	Cleanup: func(*rt.Runtime) { cleanupCurrentFiles() },
+	Load: load,
+	Name: "io",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	methods := rt.NewTable()
 
 	rt.SolemnlyDeclareCompliance(
@@ -61,13 +59,14 @@ func load(r *rt.Runtime) rt.Value {
 	}
 
 	stdoutFile := NewFile(os.Stdout, stdoutOpts)
+	stderrFile := NewFile(os.Stderr, stderrOpts)
 	// This is not a good pattern - it has to do for now.
 	if r.Stdout == nil {
 		r.Stdout = stdoutFile.writer
 	}
 	stdin := newFileUserData(NewFile(os.Stdin, stdinOpts), meta)
 	stdout := newFileUserData(stdoutFile, meta)
-	stderr := newFileUserData(NewFile(os.Stderr, stderrOpts), meta) // I''m guessing, don't buffer stderr?
+	stderr := newFileUserData(stderrFile, meta) // I''m guessing, don't buffer stderr?
 
 	r.SetRegistry(ioKey, rt.AsValue(&ioData{
 		defaultOutput: stdout,
@@ -99,7 +98,15 @@ func load(r *rt.Runtime) rt.Value {
 
 		r.SetEnvGoFunc(pkg, "type", typef, 1, false),
 	)
-	return rt.TableValue(pkg)
+
+	// This function should make sure known buffers are flushed before quitting
+	var cleanup = func() {
+		getIoData(r).defaultOutputFile().Flush()
+		stdoutFile.Flush()
+		stderrFile.Flush()
+	}
+
+	return rt.TableValue(pkg), cleanup
 }
 
 type ioData struct {
@@ -108,8 +115,8 @@ type ioData struct {
 	metatable     *rt.Table
 }
 
-func getIoData(t *rt.Thread) *ioData {
-	return t.Registry(ioKey).Interface().(*ioData)
+func getIoData(r *rt.Runtime) *ioData {
+	return r.Registry(ioKey).Interface().(*ioData)
 }
 
 func (d *ioData) defaultOutputFile() *File {
@@ -132,7 +139,7 @@ func pushingNextIoResult(r *rt.Runtime, c *rt.GoCont, ioErr error) (rt.Cont, *rt
 func ioclose(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	var f *File
 	if c.NArgs() == 0 {
-		f = getIoData(t).defaultOutputFile()
+		f = getIoData(t.Runtime).defaultOutputFile()
 	} else {
 		var err *rt.Error
 		f, err = FileArg(c, 0)
@@ -153,7 +160,7 @@ func fileclose(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 func ioflush(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	var f *File
 	if c.NArgs() == 0 {
-		f = getIoData(t).defaultOutputFile()
+		f = getIoData(t.Runtime).defaultOutputFile()
 	} else {
 		var err *rt.Error
 		f, err = FileArg(c, 0)
@@ -176,7 +183,7 @@ func errFileOrFilename() *rt.Error {
 }
 
 func input(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	ioData := getIoData(t)
+	ioData := getIoData(t.Runtime)
 	if c.NArgs() == 0 {
 		return c.PushingNext1(t.Runtime, rt.UserDataValue(ioData.defaultInput)), nil
 	}
@@ -205,7 +212,7 @@ func input(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 }
 
 func output(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	ioData := getIoData(t)
+	ioData := getIoData(t.Runtime)
 	if c.NArgs() == 0 {
 		return c.PushingNext1(t.Runtime, rt.UserDataValue(ioData.defaultOutput)), nil
 	}
@@ -241,7 +248,7 @@ func iolines(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 		eofAction = closeAtEOF
 	)
 	if c.NArgs() == 0 || c.Arg(0) == rt.NilValue {
-		f = getIoData(t).defaultInputFile()
+		f = getIoData(t.Runtime).defaultInputFile()
 		eofAction = doNotCloseAtEOF
 	} else {
 		fname, err := c.StringArg(0)
@@ -331,7 +338,7 @@ func open(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	if ioErr != nil {
 		return pushingNextIoResult(t.Runtime, c, ioErr)
 	}
-	u := newFileUserData(f, getIoData(t).metatable)
+	u := newFileUserData(f, getIoData(t.Runtime).metatable)
 	return c.PushingNext(t.Runtime, rt.UserDataValue(u)), nil
 }
 
@@ -352,7 +359,7 @@ func typef(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 }
 
 func iowrite(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	return write(t.Runtime, rt.UserDataValue(getIoData(t).defaultOutput), c)
+	return write(t.Runtime, rt.UserDataValue(getIoData(t.Runtime).defaultOutput), c)
 }
 
 func filewrite(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
@@ -469,7 +476,7 @@ func tmpfile(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	if err != nil {
 		return nil, rt.NewErrorE(err)
 	}
-	fv := newFileUserData(f, getIoData(t).metatable)
+	fv := newFileUserData(f, getIoData(t.Runtime).metatable)
 	return c.PushingNext(t.Runtime, rt.UserDataValue(fv)), nil
 }
 
@@ -492,12 +499,5 @@ func tostring(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 }
 
 func newFileUserData(f *File, meta *rt.Table) *rt.UserData {
-	u := rt.NewUserData(f, meta)
-	runtime.SetFinalizer(u, finalizeFileUserData)
-	return u
-}
-
-func finalizeFileUserData(u *rt.UserData) {
-	f := u.Value().(*File)
-	f.release()
+	return rt.NewUserData(f, meta)
 }

--- a/lib/iolib/lua/iolib.lua
+++ b/lib/iolib/lua/iolib.lua
@@ -240,6 +240,70 @@ do
     io.write("hello")
     io.write("bye")
     io.close()
+    print(pcall(io.close))
+    --> ~false\t.*file already closed
     print(io.open("files/outputtest.txt"):read())
     --> =hellobye
+end
+
+do
+    local f = io.open("files/iotest.txt")
+    print(f:read(0))
+    --> =
+    print(f:read("L"))
+    --> =hello
+    --> =
+    print(f:read("n"))
+    --> =123
+    print(f:read("n"))
+    --> =nil
+    print(f:read("a"))
+    --> =bye
+    --> =
+    print(f:read(0))
+    --> =nil
+end
+
+do
+    print(io.stdout:close())
+    --> ~nil\t.*cannot close standard file
+
+    print(io.stdin:close())
+    --> ~nil\t.*cannot close standard file
+
+    print(io.stderr:close())
+    --> ~nil\t.*cannot close standard file
+end
+
+do
+    local f = io.open("files/writetest3.txt", "w")
+    -- hard to test what it does, at least make sure the correct modes are accepted
+    f:setvbuf("no")
+    f:setvbuf("full")
+    f:setvbuf("line")
+    f:setvbuf("full", 0)
+    f:setvbuf("full", 2000)
+    f:setvbuf("line", 1000)
+
+    local function perr(...)
+        print(pcall(function(...) f:setvbuf(...) end, ...))
+    end
+
+    perr("line", -1)
+    --> ~false\t.*invalid buffer size
+
+    perr("full", -1000)
+    --> ~false\t.*invalid buffer size
+
+    perr("blah")
+    --> ~false\t.*invalid buffer mode
+
+    perr()
+    --> ~false\t.*2 arguments needed
+
+    perr(100)
+    --> ~false\t.*#2 must be a string
+
+    perr("full", {})
+    --> ~false\t.*#3 must be an integer
 end

--- a/lib/iolib/read.go
+++ b/lib/iolib/read.go
@@ -13,7 +13,7 @@ func ioread(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	if fmtErr != nil {
 		return nil, rt.NewErrorE(fmtErr)
 	}
-	ioErr := read(t.Runtime, getIoData(t).defaultInputFile(), readers, next)
+	ioErr := read(t.Runtime, getIoData(t.Runtime).defaultInputFile(), readers, next)
 	if ioErr != nil && ioErr != io.EOF {
 		return t.ProcessIoError(c.Next(), ioErr)
 	}

--- a/lib/mathlib/mathlib.go
+++ b/lib/mathlib/mathlib.go
@@ -13,7 +13,7 @@ var LibLoader = packagelib.Loader{
 	Name: "math",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 	r.SetEnv(pkg, "huge", rt.FloatValue(math.Inf(1)))
 	r.SetEnv(pkg, "maxinteger", rt.IntValue(math.MaxInt64))
@@ -48,7 +48,7 @@ func load(r *rt.Runtime) rt.Value {
 		r.SetEnvGoFunc(pkg, "ult", ult, 2, false),
 	)
 
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 func abs(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/oslib/oslib.go
+++ b/lib/oslib/oslib.go
@@ -17,7 +17,7 @@ var LibLoader = packagelib.Loader{
 	Name: "os",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 
 	rt.SolemnlyDeclareCompliance(
@@ -36,7 +36,7 @@ func load(r *rt.Runtime) rt.Value {
 	// put them in.
 	r.SetEnvGoFunc(pkg, "setlocale", setlocale, 2, false)
 	r.SetEnvGoFunc(pkg, "exit", exit, 2, false)
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 func clock(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/runtimelib/runtimelib.go
+++ b/lib/runtimelib/runtimelib.go
@@ -12,9 +12,9 @@ var LibLoader = packagelib.Loader{
 	Name: "runtime",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	if !rt.QuotasAvailable {
-		return rt.NilValue
+		return rt.NilValue, nil
 	}
 	pkg := rt.NewTable()
 
@@ -30,7 +30,7 @@ func load(r *rt.Runtime) rt.Value {
 
 	createContextMetatable(r)
 
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 func context(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/stringlib/stringlib.go
+++ b/lib/stringlib/stringlib.go
@@ -7,7 +7,13 @@ import (
 	rt "github.com/arnodel/golua/runtime"
 )
 
-func load(r *rt.Runtime) rt.Value {
+// LibLoader specifies how to load the string lib
+var LibLoader = packagelib.Loader{
+	Load: load,
+	Name: "string",
+}
+
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 	pkgVal := rt.TableValue(pkg)
 
@@ -37,13 +43,7 @@ func load(r *rt.Runtime) rt.Value {
 	r.SetEnv(stringMeta, "__index", pkgVal)
 	r.SetStringMeta(stringMeta)
 
-	return pkgVal
-}
-
-// LibLoader specifies how to load the string lib
-var LibLoader = packagelib.Loader{
-	Load: load,
-	Name: "string",
+	return pkgVal, nil
 }
 
 func maxpos(i, j int) int {

--- a/lib/tablelib/tablelib.go
+++ b/lib/tablelib/tablelib.go
@@ -16,7 +16,7 @@ var LibLoader = packagelib.Loader{
 	Name: "table",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 
 	rt.SolemnlyDeclareCompliance(
@@ -31,7 +31,7 @@ func load(r *rt.Runtime) rt.Value {
 		r.SetEnvGoFunc(pkg, "unpack", unpack, 3, false),
 	)
 
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 func concat(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/utf8lib/utf8lib.go
+++ b/lib/utf8lib/utf8lib.go
@@ -14,7 +14,7 @@ var LibLoader = packagelib.Loader{
 	Name: "utf8",
 }
 
-func load(r *rt.Runtime) rt.Value {
+func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
 	r.SetEnv(pkg, "charpattern", rt.StringValue("[\x00-\x7F\xC2-\xF4][\x80-\xBF]*"))
 
@@ -28,7 +28,7 @@ func load(r *rt.Runtime) rt.Value {
 		r.SetEnvGoFunc(pkg, "offset", offset, 3, false),
 	)
 
-	return rt.TableValue(pkg)
+	return rt.TableValue(pkg), nil
 }
 
 func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {


### PR DESCRIPTION
The iolib is keeping a global list of files to cleanup at exit, which will not work if more than one runtime is used.  Also the usefulness of keeping a list of all files is dubious.