### PR TITLE
Implement Lua 5.4 to-be-closed

### DIFF
--- a/ast/localstat.go
+++ b/ast/localstat.go
@@ -41,28 +41,29 @@ func (s LocalStat) HWrite(w HWriter) {
 	w.Dedent()
 }
 
+type LocalAttrib uint8
+
+const (
+	NoAttrib LocalAttrib = iota
+	ConstAttrib
+	CloseAttrib
+)
+
 type NameAttrib struct {
 	Location
 	Name   Name
-	Attrib *Name
+	Attrib LocalAttrib
 }
 
-func NewNameAttrib(name Name, attrib *Name) NameAttrib {
+func NewNameAttrib(name Name, attribName *Name, attrib LocalAttrib) NameAttrib {
 	loc := name.Location
-	if attrib != nil {
-		loc = MergeLocations(loc, attrib)
+	if attribName != nil {
+		loc = MergeLocations(loc, attribName)
+
 	}
 	return NameAttrib{
 		Location: loc,
 		Name:     name,
 		Attrib:   attrib,
 	}
-}
-
-func (na NameAttrib) IsConst() bool {
-	return na.Attrib != nil && na.Attrib.Val == "const"
-}
-
-func (na NameAttrib) IsClose() bool {
-	return na.Attrib != nil && na.Attrib.Val == "close"
 }

--- a/ast/localstat.go
+++ b/ast/localstat.go
@@ -62,3 +62,7 @@ func NewNameAttrib(name Name, attrib *Name) NameAttrib {
 func (na NameAttrib) IsConst() bool {
 	return na.Attrib != nil && na.Attrib.Val == "const"
 }
+
+func (na NameAttrib) IsClose() bool {
+	return na.Attrib != nil && na.Attrib.Val == "close"
+}

--- a/ast/localstat.go
+++ b/ast/localstat.go
@@ -41,20 +41,25 @@ func (s LocalStat) HWrite(w HWriter) {
 	w.Dedent()
 }
 
+// LocalAttrib is the type of a local name attrib
 type LocalAttrib uint8
 
+// Valid values for LocalAttrib
 const (
-	NoAttrib LocalAttrib = iota
-	ConstAttrib
-	CloseAttrib
+	NoAttrib    LocalAttrib = iota
+	ConstAttrib             // <const>, introduced in Lua 5.4
+	CloseAttrib             // <close>, introduced in Lua 5.4
 )
 
+// A NameAttrib is a name introduce by a local definition, together with an
+// optional attribute (in Lua 5.4 that is 'close' or 'const').
 type NameAttrib struct {
 	Location
 	Name   Name
 	Attrib LocalAttrib
 }
 
+// NewNameAttrib returns a new NameAttribe for the given name and attrib.
 func NewNameAttrib(name Name, attribName *Name, attrib LocalAttrib) NameAttrib {
 	loc := name.Location
 	if attribName != nil {

--- a/astcomp/compstat.go
+++ b/astcomp/compstat.go
@@ -59,7 +59,7 @@ func (c *compiler) ProcessForInStat(s ast.ForInStat) {
 
 	nameAttribs := make([]ast.NameAttrib, len(s.Vars))
 	for i, name := range s.Vars {
-		nameAttribs[i] = ast.NewNameAttrib(name, nil)
+		nameAttribs[i] = ast.NewNameAttrib(name, nil, ast.NoAttrib)
 	}
 	c.CompileStat(ast.LocalStat{
 		NameAttribs: nameAttribs,
@@ -265,12 +265,16 @@ func (c *compiler) ProcessLocalStat(s ast.LocalStat) {
 	for i, reg := range localRegs {
 		c.ReleaseRegister(reg)
 		c.DeclareLocal(ir.Name(s.NameAttribs[i].Name.Val), reg)
-		switch na := s.NameAttribs[i]; {
-		case na.IsConst():
+		switch s.NameAttribs[i].Attrib {
+		case ast.NoAttrib:
+			// Nothing to do
+		case ast.ConstAttrib:
 			c.MarkConstantReg(reg)
-		case na.IsClose():
+		case ast.CloseAttrib:
 			c.MarkConstantReg(reg)
 			c.PushCloseAction(reg)
+		default:
+			panic(compilerBug{})
 		}
 	}
 }

--- a/astcomp/compstat.go
+++ b/astcomp/compstat.go
@@ -265,8 +265,12 @@ func (c *compiler) ProcessLocalStat(s ast.LocalStat) {
 	for i, reg := range localRegs {
 		c.ReleaseRegister(reg)
 		c.DeclareLocal(ir.Name(s.NameAttribs[i].Name.Val), reg)
-		if s.NameAttribs[i].IsConst() {
+		switch na := s.NameAttribs[i]; {
+		case na.IsConst():
 			c.MarkConstantReg(reg)
+		case na.IsClose():
+			c.MarkConstantReg(reg)
+			c.PushCloseAction(reg)
 		}
 	}
 }

--- a/code/instructions.go
+++ b/code/instructions.go
@@ -140,10 +140,20 @@ func TailCall(r Reg) Opcode {
 	return mkType5(On, OpCall, r, Offset(0))
 }
 
+// ClTrunc encodes cltrunc h
+//
+// It truncates the close stack to the given height.  Each value on the close
+// stack which is removed should either be nil or false, or be a value with a
+// "__close" metamethod, in which case this metamethod is called.  This opcode
+// is introduced to support Lua 5.4's "to-be-closed" variables.
 func ClTrunc(h uint16) Opcode {
 	return mkType5(Off, OpClStack, Reg{}, ClStackOffset(h))
 }
 
+// ClPush encodes clpush r
+//
+// r should contain either nil, false, or a value with a "__close" metamethod.
+// This opcode is introduced to support Lua 5.4's "to-be-closed" variables.
 func ClPush(r Reg) Opcode {
 	return mkType5(On, OpClStack, r, ClStackOffset(0))
 }

--- a/code/instructions.go
+++ b/code/instructions.go
@@ -130,14 +130,22 @@ func JumpIfNot(j Offset, r Reg) Opcode {
 //
 // r must contain a continuation that is ready to be called.
 func Call(r Reg) Opcode {
-	return mkType5(Off, OpCall, r, 0)
+	return mkType5(Off, OpCall, r, Offset(0))
 }
 
 // TailCall encodes tailcall r
 //
 // r must contain a continuation that is ready to be called.
 func TailCall(r Reg) Opcode {
-	return mkType5(On, OpCall, r, 0)
+	return mkType5(On, OpCall, r, Offset(0))
+}
+
+func ClTrunc(h uint16) Opcode {
+	return mkType5(Off, OpClStack, Reg{}, ClStackOffset(h))
+}
+
+func ClPush(r Reg) Opcode {
+	return mkType5(On, OpClStack, r, ClStackOffset(0))
 }
 
 // Upval encodes upval r1, r2

--- a/code/opcodes.go
+++ b/code/opcodes.go
@@ -357,6 +357,7 @@ func (d Offset) encodeD() Opcode {
 	return Opcode(uint16(d))
 }
 
+// ClStackOffset is an offset from the bottom of the close stack
 type ClStackOffset uint16
 
 func (d ClStackOffset) encodeD() Opcode {

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -166,6 +166,8 @@ func (c *CodeBuilder) emitClearReg(m lexicalScope) {
 	}
 }
 
+// PushCloseAction emits a PushCloseStack instruction and updates the current
+// lexical context accordingly
 func (c *CodeBuilder) PushCloseAction(reg Register) {
 	c.context.addHeight(1)
 	c.EmitNoLine(PushCloseStack{Src: reg})

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -150,6 +150,7 @@ func (c *CodeBuilder) PopContext() {
 	if top.reg == nil {
 		panic("Cannot pop empty context")
 	}
+	c.emitTruncate(context.top())
 	c.context = context
 	c.emitClearReg(top)
 	for _, tr := range top.reg {
@@ -165,12 +166,26 @@ func (c *CodeBuilder) emitClearReg(m lexicalScope) {
 	}
 }
 
+func (c *CodeBuilder) PushCloseAction(reg Register) {
+	c.context.addHeight(1)
+	c.EmitNoLine(PushCloseStack{Src: reg})
+}
+
+func (c *CodeBuilder) emitTruncate(m lexicalScope) {
+	if m.height < c.context.top().height {
+		c.EmitNoLine(TruncateCloseStack{Height: m.height})
+	}
+}
+
 func (c *CodeBuilder) EmitJump(lblName Name, line int) bool {
-	lc := c.context
-	var top lexicalScope
+	var (
+		lc  = c.context
+		top lexicalScope
+	)
 	for len(lc) > 0 {
 		lc, top = lc.pop()
 		if lbl, ok := top.label[lblName]; ok {
+			c.emitTruncate(top)
 			c.Emit(Jump{Label: lbl}, line)
 			return true
 		}

--- a/ir/context.go
+++ b/ir/context.go
@@ -3,8 +3,9 @@ package ir
 import "fmt"
 
 type lexicalScope struct {
-	reg   map[Name]taggedReg
-	label map[Name]Label
+	reg    map[Name]taggedReg
+	label  map[Name]Label
+	height int
 }
 
 type taggedReg struct {
@@ -78,12 +79,22 @@ func (c lexicalContext) addLabel(name Name, label Label) (ok bool) {
 	return
 }
 
+// addHeight increases the height of the topmost lexical scope in this context.
+func (c lexicalContext) addHeight(h int) (ok bool) {
+	ok = len(c) > 0
+	if ok {
+		c[len(c)-1].height += h
+	}
+	return ok
+}
+
 // pushNew returns a new LexicalContext that extends the receive with a new
 // blank lexical scope.
 func (c lexicalContext) pushNew() lexicalContext {
 	return append(c, lexicalScope{
-		reg:   make(map[Name]taggedReg),
-		label: make(map[Name]Label),
+		reg:    make(map[Name]taggedReg),
+		label:  make(map[Name]Label),
+		height: c.top().height,
 	})
 }
 

--- a/ir/context.go
+++ b/ir/context.go
@@ -3,9 +3,9 @@ package ir
 import "fmt"
 
 type lexicalScope struct {
-	reg    map[Name]taggedReg
-	label  map[Name]Label
-	height int
+	reg    map[Name]taggedReg // maps variable names to registers
+	label  map[Name]Label     // maps label names to labels
+	height int                // This is the height of the close stack in this scope
 }
 
 type taggedReg struct {

--- a/ir/instructions.go
+++ b/ir/instructions.go
@@ -420,6 +420,9 @@ func (f FillTable) ProcessInstr(p InstrProcessor) {
 	p.ProcessFillTableInstr(f)
 }
 
+// TruncateCloseStack truncates the close stack to Height (which should be >=
+// 0).  This instruction was introduced to support to-be-closed variables which
+// are part of Lua 5.4
 type TruncateCloseStack struct {
 	Height int
 }
@@ -428,10 +431,14 @@ func (t TruncateCloseStack) String() string {
 	return fmt.Sprintf("trunc close stack to %d", t.Height)
 }
 
+// ProcessInstr makes the InstrProcessor process this instruction.
 func (t TruncateCloseStack) ProcessInstr(p InstrProcessor) {
 	p.ProcessTruncateCloseStackInstr(t)
 }
 
+// PushCloseStack truncates pushes the value Src to the close stack.  This
+// instruction was introduced to support to-be-closed variables which are part
+// of Lua 5.4
 type PushCloseStack struct {
 	Src Register
 }
@@ -440,6 +447,7 @@ func (i PushCloseStack) String() string {
 	return fmt.Sprintf("push %s to close stack", i.Src)
 }
 
+// ProcessInstr makes the InstrProcessor process this instruction.
 func (i PushCloseStack) ProcessInstr(p InstrProcessor) {
 	p.ProcessPushCloseStackInstr(i)
 }

--- a/ir/instructions.go
+++ b/ir/instructions.go
@@ -41,6 +41,8 @@ type InstrProcessor interface {
 	ProcessReceiveEtcInstr(ReceiveEtc)
 	ProcessEtcLookupInstr(EtcLookup)
 	ProcessFillTableInstr(FillTable)
+	ProcessTruncateCloseStackInstr(TruncateCloseStack)
+	ProcessPushCloseStackInstr(PushCloseStack)
 
 	// These are hints that a register is needed or no longer needed.
 	ProcessTakeRegisterInstr(TakeRegister)
@@ -416,6 +418,30 @@ func (f FillTable) String() string {
 // ProcessInstr makes the InstrProcessor process this instruction.
 func (f FillTable) ProcessInstr(p InstrProcessor) {
 	p.ProcessFillTableInstr(f)
+}
+
+type TruncateCloseStack struct {
+	Height int
+}
+
+func (t TruncateCloseStack) String() string {
+	return fmt.Sprintf("trunc close stack to %d", t.Height)
+}
+
+func (t TruncateCloseStack) ProcessInstr(p InstrProcessor) {
+	p.ProcessTruncateCloseStackInstr(t)
+}
+
+type PushCloseStack struct {
+	Src Register
+}
+
+func (i PushCloseStack) String() string {
+	return fmt.Sprintf("push %s to close stack", i.Src)
+}
+
+func (i PushCloseStack) ProcessInstr(p InstrProcessor) {
+	p.ProcessPushCloseStackInstr(i)
 }
 
 // TakeRegister is not a real instruction.  It is a hint to the next stage that

--- a/ircomp/compinstr.go
+++ b/ircomp/compinstr.go
@@ -214,6 +214,17 @@ func (ic instrCompiler) ProcessFillTableInstr(f ir.FillTable) {
 	ic.Emit(code.FillTable(ic.codeReg(f.Dst), ic.codeReg(f.Etc), f.Idx))
 }
 
+func (ic instrCompiler) ProcessTruncateCloseStackInstr(t ir.TruncateCloseStack) {
+	if t.Height < 0 || t.Height >= 65536 {
+		panic("close stack height out of range")
+	}
+	ic.Emit(code.ClTrunc(uint16(t.Height)))
+}
+
+func (ic instrCompiler) ProcessPushCloseStackInstr(p ir.PushCloseStack) {
+	ic.Emit(code.ClPush(ic.codeReg(p.Src)))
+}
+
 func (ic instrCompiler) ProcessTakeRegisterInstr(t ir.TakeRegister) {
 	ic.takeRegister(t.Reg)
 

--- a/ircomp/compinstr.go
+++ b/ircomp/compinstr.go
@@ -214,6 +214,7 @@ func (ic instrCompiler) ProcessFillTableInstr(f ir.FillTable) {
 	ic.Emit(code.FillTable(ic.codeReg(f.Dst), ic.codeReg(f.Etc), f.Idx))
 }
 
+// ProcessTruncateCloseStackInstr compiles a TruncateCloseStack instruction.
 func (ic instrCompiler) ProcessTruncateCloseStackInstr(t ir.TruncateCloseStack) {
 	if t.Height < 0 || t.Height >= 65536 {
 		panic("close stack height out of range")
@@ -221,6 +222,7 @@ func (ic instrCompiler) ProcessTruncateCloseStackInstr(t ir.TruncateCloseStack) 
 	ic.Emit(code.ClTrunc(uint16(t.Height)))
 }
 
+// ProcessPushCloseStackInstr compiles a PushCloseStack instruction.
 func (ic instrCompiler) ProcessPushCloseStackInstr(p ir.PushCloseStack) {
 	ic.Emit(code.ClPush(ic.codeReg(p.Src)))
 }

--- a/lib/coroutine/coroutine.go
+++ b/lib/coroutine/coroutine.go
@@ -17,6 +17,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 	rt.SolemnlyDeclareCompliance(
 		rt.ComplyCpuSafe|rt.ComplyMemSafe|rt.ComplyTimeSafe|rt.ComplyIoSafe,
 
+		r.SetEnvGoFunc(pkg, "close", close, 1, false),
 		r.SetEnvGoFunc(pkg, "create", create, 1, false),
 		r.SetEnvGoFunc(pkg, "isyieldable", isyieldable, 0, false),
 		r.SetEnvGoFunc(pkg, "resume", resume, 1, true),
@@ -27,6 +28,23 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 	)
 
 	return rt.TableValue(pkg), nil
+}
+
+func close(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+	if err := c.Check1Arg(); err != nil {
+		return nil, err
+	}
+	co, err := c.ThreadArg(0)
+	if err != nil {
+		return nil, err
+	}
+	err = co.Close(t)
+	next := c.Next()
+	t.Push1(next, rt.BoolValue(err == nil))
+	if err != nil {
+		t.Push1(next, err.Value())
+	}
+	return next, nil
 }
 
 func create(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/coroutine/coroutine.go
+++ b/lib/coroutine/coroutine.go
@@ -17,7 +17,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 	rt.SolemnlyDeclareCompliance(
 		rt.ComplyCpuSafe|rt.ComplyMemSafe|rt.ComplyTimeSafe|rt.ComplyIoSafe,
 
-		r.SetEnvGoFunc(pkg, "close", close, 1, false),
+		r.SetEnvGoFunc(pkg, "close", close, 1, false), // Lua 5.4
 		r.SetEnvGoFunc(pkg, "create", create, 1, false),
 		r.SetEnvGoFunc(pkg, "isyieldable", isyieldable, 0, false),
 		r.SetEnvGoFunc(pkg, "resume", resume, 1, true),

--- a/lib/coroutine/lua/coroutine.lua
+++ b/lib/coroutine/lua/coroutine.lua
@@ -89,3 +89,36 @@ do
     print(fib(), fib(), fib(), fib(), fib())
     --> =0	1	1	2	3
 end
+
+-- Test coroutine.close() (5.4)
+do
+    print(pcall(coroutine.close))
+    --> ~false\t.*value needed
+
+    print(pcall(coroutine.close, 1))
+    --> ~false\t.*must be a thread
+
+    print(pcall(coroutine.close, coroutine.running()))
+    --> ~true\tfalse\t.*cannot close running thread
+
+    local co = coroutine.create(function()
+        coroutine.yield()
+    end)
+
+    coroutine.resume(co)
+    print(coroutine.close(co))
+    --> =true
+    print(coroutine.status(co))
+    --> =dead
+    local co = coroutine.create(function()
+        local x <close> = {}
+        setmetatable(x, {__close=function() error("ERR") end})
+        coroutine.yield()
+    end)
+    coroutine.resume(co)
+    pcall(function() print(coroutine.close(co)) end)
+    --> ~false\t.*ERR
+
+    print(coroutine.status(co))
+    --> =dead
+end

--- a/notes/to-be-closed.md
+++ b/notes/to-be-closed.md
@@ -1,0 +1,68 @@
+# Implementation notes for to-be-closed variables
+
+This is a feature introduced in Lua 5.4.  See
+https://www.lua.org/manual/5.4/manual.html#3.3.8
+
+## Approach
+
+I try to give a succinct explanation of the implementation approach.
+
+### Height of a lexical scope
+
+During AST -> IR compilation, a **height** is assigned to each lexical scope.
+If L2 is a lexical scope with parent L1, then
+
+    height(L2) = height(L1) + n, where n is the number of to-be-closed variables that L2 defines
+
+If L is a root lexical scope (i.e. it is the outermost block in a function body)
+then
+
+    height(L) = 0
+
+### Code generation
+
+There are 2 new opcodes:
+- `clpush <reg>`: push the contents of `<reg>` onto the close stack
+- `cltrunc h`: truncate the close stack to height `h` (`h` is encoded in the
+  opcode and must be known at compile time)
+
+This is how the opcodes are inserted
+- Whenever a to-be-closed varable is defined (`local x <close> = val`), a
+  `clpush r1` instruction is emitted, where `r1` is the register containing
+  `val`.
+- Whenever a lexical scope L is exited, a `cltrunc h` instruction is emitted where `h` is the height of the parent scope of `L`
+- Whenever a Jump is emitted, just before the jump is emitted a `cltrunc h`
+  instruction is emitted where `h` is the height of the lexical scope of the
+  jump destination.
+
+### Runtime
+
+There are two aspects to the runtime machinery - normal execution of Lua
+continutaions and error handling
+
+#### Normal execution of Lua continuations
+
+Each Lua continuation maintains a **close stack**, which is a stack of Lua
+values. It starts empty and is modified as follows
+- `clpush <reg>` pushes the value of `<reg>` on top of the close stack
+- `cltrunc h` pops values from the top of the close stack and executes their
+  `__close` metamethod until the height of the close stack is at most `h`.
+- When returning from a Lua function (return OR tail-call), a `cltrunc 0`
+  instruction is executed.
+
+#### Error handling
+
+If there is an error, then all close stacks in the "call stack" should be called
+until the error is caught.  This is achieve by adding a `Cleanup()` method to
+the `runtime.Cont` interface, which must be implemented by each continuation
+type.   The runtime loop will call those in turn down the call stack when an
+error is encountered.  For a Lua continuation, `Cleanup()` is roughly equivalent
+to `cltrunc 0`.
+
+#### Coroutines
+
+Lua 5.4 adds a `coroutine.close()` function that allows stopping a suspended
+coroutine but executing all pending to-be-closed variables.  Given the approach
+above this is simply a matter of executing the `Cleanup()` method on the
+suspended thread's current continuation and its successors.
+

--- a/parsing/parser.go
+++ b/parsing/parser.go
@@ -610,12 +610,24 @@ func (p *Parser) Name(t *token.Token) (ast.Name, *token.Token) {
 
 func (p *Parser) NameAttrib(t *token.Token) (ast.NameAttrib, *token.Token) {
 	name, t := p.Name(t)
-	if t.Type != token.SgLess {
-		return ast.NameAttrib{Name: name}, t
+	attrib := ast.NoAttrib
+	var attribName *ast.Name
+	if t.Type == token.SgLess {
+		attribTok := p.Scan()
+		attribName = new(ast.Name)
+		*attribName, t = p.Name(attribTok)
+		switch attribName.Val {
+		case "const":
+			attrib = ast.ConstAttrib
+		case "close":
+			attrib = ast.CloseAttrib
+		default:
+			tokenError(attribTok, "'const' or 'close'")
+		}
+		expectType(t, token.SgGreater, "'>'")
+		t = p.Scan()
 	}
-	attrib, t := p.Name(p.Scan())
-	expectType(t, token.SgGreater, "'>'")
-	return ast.NameAttrib{Name: name, Attrib: &attrib}, p.Scan()
+	return ast.NewNameAttrib(name, attribName, attrib), t
 }
 
 func expectIdent(t *token.Token) {

--- a/parsing/parser.go
+++ b/parsing/parser.go
@@ -622,7 +622,7 @@ func (p *Parser) NameAttrib(t *token.Token) (ast.NameAttrib, *token.Token) {
 		case "close":
 			attrib = ast.CloseAttrib
 		default:
-			tokenError(attribTok, "'const' or 'close'")
+			tokenError(attribTok, "expected 'const' or 'close'")
 		}
 		expectType(t, token.SgGreater, "'>'")
 		t = p.Scan()

--- a/parsing/parser_test.go
+++ b/parsing/parser_test.go
@@ -37,12 +37,18 @@ func tok(tp token.Type, lit string) *token.Token {
 func name(s string) ast.Name {
 	return ast.Name{Val: s}
 }
-func nameAttrib(s string, attrib ...string) ast.NameAttrib {
-	var attribName *ast.Name
-	if len(attrib) > 0 {
-		attribName = &ast.Name{Val: attrib[0]}
+
+func nameAttrib(s string, attribs ...string) ast.NameAttrib {
+	var attrib = ast.NoAttrib
+	if len(attribs) > 0 {
+		switch attribs[0] {
+		case "close":
+			attrib = ast.CloseAttrib
+		case "const":
+			attrib = ast.ConstAttrib
+		}
 	}
-	return ast.NameAttrib{Name: name(s), Attrib: attribName}
+	return ast.NameAttrib{Name: name(s), Attrib: attrib}
 }
 
 func str(s string) ast.String {

--- a/runtime/cont.go
+++ b/runtime/cont.go
@@ -17,6 +17,7 @@ type Cont interface {
 	Next() Cont
 	Parent() Cont
 	DebugInfo() *DebugInfo
+	Cleanup(*Thread, *Error) *Error
 }
 
 // Push is a convenience method that pushes a number of values to the

--- a/runtime/cont.go
+++ b/runtime/cont.go
@@ -17,6 +17,14 @@ type Cont interface {
 	Next() Cont
 	Parent() Cont
 	DebugInfo() *DebugInfo
+
+	// This will be called on pending continuations when the previous
+	// continuation returned with an error.  If there is nothing to do it should
+	// return the error unchanged, otherwise if it encounters another error
+	// during execution it may return the new error.
+	//
+	// This was intruduced to implement to-be-closed variables, a feature of Lua
+	// 5.4.
 	Cleanup(*Thread, *Error) *Error
 }
 

--- a/runtime/error.go
+++ b/runtime/error.go
@@ -84,6 +84,9 @@ func (e *Error) AddContext(c Cont, depth int) {
 
 // Value returns the message of the error (which can be any Lua Value).
 func (e *Error) Value() Value {
+	if e == nil {
+		return NilValue
+	}
 	return e.message
 }
 

--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -129,6 +129,10 @@ func (c *GoCont) DebugInfo() *DebugInfo {
 	}
 }
 
+func (c *GoCont) Cleanup(t *Thread, err *Error) *Error {
+	return err
+}
+
 // NArgs returns the number of args pushed to the continuation.
 func (c *GoCont) NArgs() int {
 	return c.nArgs

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -1,3 +1,6 @@
+--
+-- const tests
+--
 
 local function test(src)
     local res, err = load(src)
@@ -39,6 +42,10 @@ test[[
 ]]
 --> ~false\t.*attempt to reassign constant variable 'bar'
 
+--
+-- to-be-closed tests
+--
+
 test[[
     local x <close> = nil
     x = 3
@@ -78,7 +85,9 @@ end
 --> =bb
 --> =aa
 
-local s = "start"
+
+-- A function to test to-be-closed variables
+local s
 function mk(a)
     t = {}
     s = s .. '+' .. a
@@ -86,7 +95,18 @@ function mk(a)
     return t
 end
 
+-- How it works
 do
+    s = "start"
+    local v <close> = mk("bob")
+    print(s)
+    --> =start+bob
+end
+print(s)
+--> =start+bob-bob
+
+do
+    s = "start"
     local function f()
         local a <close> = mk("a")
         for i = 1, 3 do

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -38,3 +38,69 @@ test[[
     return foo + bar
 ]]
 --> ~false\t.*attempt to reassign constant variable 'bar'
+
+test[[
+    local x <close> = nil
+    x = 3
+]]
+--> ~false\t.*attempt to reassign constant variable 'x'
+
+test[[
+    local x <close> = 1
+]]
+--> ~false\t.*to be closed variable missing a __close metamethod
+
+function make(msg)
+    t = {}
+    setmetatable(t, {__close = function () print(msg) end})
+    return t
+end
+
+do
+    local x <close> = make("x")
+    print("a")
+end
+print("b")
+--> =a
+--> =x
+--> =b
+
+do
+    local x <close> = make("x")
+    local y <close> = make("y")
+end
+--> =y
+--> =x
+
+do
+    local x <close>, y <close> = make("aa"), make("bb")
+end
+--> =bb
+--> =aa
+
+local s = "start"
+function mk(a)
+    t = {}
+    s = s .. '+' .. a
+    setmetatable(t, {__close = function () s = s .. '-' .. a end})
+    return t
+end
+
+do
+    local function f()
+        local a <close> = mk("a")
+        for i = 1, 3 do
+            local b <close> = mk("b"..i)
+        end
+        do
+            local c <close> = mk("c")
+            do
+                local d <close> = mk("d")
+                return
+            end
+        end
+    end
+    f()
+    print(s)
+    --> start+a+b1-b1+b2-b2+b3-b3+c+d-d-c-a
+end

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -102,5 +102,5 @@ do
     end
     f()
     print(s)
-    --> start+a+b1-b1+b2-b2+b3-b3+c+d-d-c-a
+    --> =start+a+b1-b1+b2-b2+b3-b3+c+d-d-c-a
 end

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -57,9 +57,18 @@ test[[
 ]]
 --> ~false\t.*to be closed variable missing a __close metamethod
 
-function make(msg)
+function make(msg, err)
     t = {}
-    setmetatable(t, {__close = function () print(msg) end})
+    setmetatable(t, {__close = function (x, e) 
+        if e ~= nil then
+            print(msg, e)
+        else
+            print(msg)
+        end
+        if err ~= nil then 
+            error(err)
+        end
+    end})
     return t
 end
 
@@ -85,6 +94,19 @@ end
 --> =bb
 --> =aa
 
+-- errors in close metamethods.  If a one produces an error, it looks like the
+-- next one is fed that error.
+pcall(function()
+    local x <close> = make("x")
+    local y <close> = make("y", "YY")
+    local z <close> = make("z")
+    local t <close> = make("t", "TT")
+    error("ERROR")
+end)
+--> ~t\t.*ERROR
+--> ~z\t.*TT
+--> ~y\t.*TT
+--> ~x\t.*YY
 
 -- A function to test to-be-closed variables
 local s

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -104,3 +104,19 @@ do
     print(s)
     --> =start+a+b1-b1+b2-b2+b3-b3+c+d-d-c-a
 end
+
+do
+    s = "start"
+    local function f(n)
+        local x <close> = mk("x"..n)
+        if n > 0 then
+            f(n - 1)
+        else
+            error("stop")
+        end
+    end
+    print(pcall(f, 3))
+    --> ~false\t.*: stop
+    print(s)
+    --> =start+x3+x2+x1+x0-x0-x1-x2-x3
+end

--- a/runtime/lua/thread.lua
+++ b/runtime/lua/thread.lua
@@ -29,6 +29,10 @@ do
     --> ~cannot yield from main thread
 end
 
+--
+-- Coroutines and to-be-closed variables
+--
+
 function make(msg, err)
     t = {}
     setmetatable(t, {__close = function (x, e) 

--- a/runtime/lua/thread.lua
+++ b/runtime/lua/thread.lua
@@ -71,42 +71,42 @@ do
         end
     end
     local co = coroutine.create(f)
-    print(coroutine.resume(co, 3))
+    coroutine.resume(co, 3)
     print(coroutine.status(co))
     --> =suspended
     print(coroutine.close(co))
     -- Output from closing the "x" vars
     --> =x1
-    --> =x1
-    --> =x1
+    --> =x2
+    --> =x3
     -- Outcome of coroutine.close(co)
     --> =true
     print(coroutine.status(co))
     --> =dead
 end
 
--- This would pass if it was not for the error messages...
--- do
---     local function f(n)
---         local x <close> = make("x"..n, "ERR"..n)
---         if n > 1 then
---             f(n - 1)
---         else
---             coroutine.yield()
---         end
---     end
---     local co = coroutine.create(f)
---     print(coroutine.resume(co, 3))
---     print(coroutine.status(co))
---     --> =suspended
---     print(coroutine.close(co))
---     -- Output from closing the "x" vars
---     --> =x1
---     --> =x1
---     --> =x1
---     -- Outcome of coroutine.close(co)
---     --> =true
---     print(coroutine.status(co))
---     --> =dead
--- end
-
+-- Wrapping this in pcall to suppress the default message handler which is
+-- adding traceback to error messages...
+pcall(function()
+    local function f(n)
+        local x <close> = make("x"..n, "ERR"..n)
+        if n > 1 then
+            f(n - 1)
+        else
+            coroutine.yield()
+        end
+    end
+    local co = coroutine.create(f)
+    coroutine.resume(co, 3)
+    print(coroutine.status(co))
+    --> =suspended
+    print(coroutine.close(co))
+    -- Output from closing the "x" vars
+    --> =x1
+    --> ~x2\t.*ERR1
+    --> ~x3\t.*ERR2
+    -- Outcome of coroutine.close(co)
+    --> ~false\t.*ERR3
+    print(coroutine.status(co))
+    --> =dead
+end)

--- a/runtime/lua/thread.lua
+++ b/runtime/lua/thread.lua
@@ -28,3 +28,85 @@ do
     print(pcall(coroutine.yield, 1))
     --> ~cannot yield from main thread
 end
+
+function make(msg, err)
+    t = {}
+    setmetatable(t, {__close = function (x, e) 
+        if e ~= nil then
+            print(msg, e)
+        else
+            print(msg)
+        end
+        if err ~= nil then 
+            error(err)
+        end
+    end})
+    return t
+end
+
+do
+    local co = coroutine.create(function ()
+        local foo <close> = make("foo")
+        coroutine.yield()
+    end)
+    coroutine.resume(co)
+    print(coroutine.status(co))
+    --> =suspended
+    print(coroutine.close(co))
+    -- Output from closing the "foo" var
+    --> =foo
+    -- Outcome of coroutine.close(co)
+    --> =true
+    print(coroutine.status(co))
+    --> =dead
+end
+
+do
+    local function f(n)
+        local x <close> = make("x"..n)
+        if n > 1 then
+            f(n - 1)
+        else
+            coroutine.yield()
+        end
+    end
+    local co = coroutine.create(f)
+    print(coroutine.resume(co, 3))
+    print(coroutine.status(co))
+    --> =suspended
+    print(coroutine.close(co))
+    -- Output from closing the "x" vars
+    --> =x1
+    --> =x1
+    --> =x1
+    -- Outcome of coroutine.close(co)
+    --> =true
+    print(coroutine.status(co))
+    --> =dead
+end
+
+-- This would pass if it was not for the error messages...
+-- do
+--     local function f(n)
+--         local x <close> = make("x"..n, "ERR"..n)
+--         if n > 1 then
+--             f(n - 1)
+--         else
+--             coroutine.yield()
+--         end
+--     end
+--     local co = coroutine.create(f)
+--     print(coroutine.resume(co, 3))
+--     print(coroutine.status(co))
+--     --> =suspended
+--     print(coroutine.close(co))
+--     -- Output from closing the "x" vars
+--     --> =x1
+--     --> =x1
+--     --> =x1
+--     -- Outcome of coroutine.close(co)
+--     --> =true
+--     print(coroutine.status(co))
+--     --> =dead
+-- end
+

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -16,7 +16,7 @@ type LuaCont struct {
 	acc           []Value
 	running       bool
 	borrowedCells bool
-	closeStack    []Value
+	closeStack    []Value // Pending to-be-closed variables
 }
 
 var _ Cont = (*LuaCont)(nil)

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -16,6 +16,7 @@ type LuaCont struct {
 	acc           []Value
 	running       bool
 	borrowedCells bool
+	closeStack    []Value
 }
 
 var _ Cont = (*LuaCont)(nil)
@@ -360,9 +361,26 @@ RunLoop:
 					// It's a tail call.  There is no error, so nothing will
 					// reference c anymore, therefore we are safe to give it to
 					// the pool for reuse.
+					if err := c.truncateCloseStack(t, 0); err != nil {
+						return nil, err
+					}
 					c.release(t.Runtime)
 				}
 				return next, nil
+			case code.OpClStack:
+				if opcode.GetF() {
+					// Push to close stack
+					v := getReg(regs, cells, opcode.GetA())
+					c.closeStack = append(c.closeStack, v)
+				} else {
+					// Truncate close stack
+					h := int(opcode.GetClStackOffset())
+					if err := c.truncateCloseStack(t, h); err != nil {
+						return nil, err
+					}
+				}
+				pc++
+				continue RunLoop
 			default:
 				panic("unsupported")
 			}
@@ -423,6 +441,23 @@ func (c *LuaCont) clearReg(reg code.Reg) {
 	} else {
 		c.registers[reg.Idx()] = NilValue
 	}
+}
+
+func (c *LuaCont) truncateCloseStack(t *Thread, h int) *Error {
+	for i := len(c.closeStack) - 1; i >= h; i-- {
+		v := c.closeStack[i]
+		c.closeStack = c.closeStack[:i]
+		if Truth(v) {
+			err, ok := Metacall(t, v, "__close", []Value{v}, NewTerminationWith(c, 0, false))
+			if !ok {
+				return NewErrorS("to be closed variable missing a __close metamethod")
+			}
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func setReg(regs []Value, cells []Cell, reg code.Reg, val Value) {

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -361,7 +361,7 @@ RunLoop:
 					// It's a tail call.  There is no error, so nothing will
 					// reference c anymore, therefore we are safe to give it to
 					// the pool for reuse.
-					if err := c.truncateCloseStack(t, 0); err != nil {
+					if err := c.truncateCloseStack(t, 0, nil); err != nil {
 						return nil, err
 					}
 					c.release(t.Runtime)
@@ -375,7 +375,7 @@ RunLoop:
 				} else {
 					// Truncate close stack
 					h := int(opcode.GetClStackOffset())
-					if err := c.truncateCloseStack(t, h); err != nil {
+					if err := c.truncateCloseStack(t, h, nil); err != nil {
 						return nil, err
 					}
 				}
@@ -428,6 +428,10 @@ func (c *LuaCont) DebugInfo() *DebugInfo {
 	}
 }
 
+func (c *LuaCont) Cleanup(t *Thread, err *Error) *Error {
+	return c.truncateCloseStack(t, 0, err)
+}
+
 func (c *LuaCont) getRegCell(reg code.Reg) Cell {
 	if reg.IsCell() {
 		return c.cells[reg.Idx()]
@@ -443,21 +447,21 @@ func (c *LuaCont) clearReg(reg code.Reg) {
 	}
 }
 
-func (c *LuaCont) truncateCloseStack(t *Thread, h int) *Error {
+func (c *LuaCont) truncateCloseStack(t *Thread, h int, err *Error) *Error {
 	for i := len(c.closeStack) - 1; i >= h; i-- {
 		v := c.closeStack[i]
 		c.closeStack = c.closeStack[:i]
 		if Truth(v) {
-			err, ok := Metacall(t, v, "__close", []Value{v}, NewTerminationWith(c, 0, false))
+			closeErr, ok := Metacall(t, v, "__close", []Value{v, err.Value()}, NewTerminationWith(c, 0, false))
 			if !ok {
 				return NewErrorS("to be closed variable missing a __close metamethod")
 			}
-			if err != nil {
-				return err
+			if closeErr != nil {
+				err = closeErr
 			}
 		}
 	}
-	return nil
+	return err
 }
 
 func setReg(regs []Value, cells []Cell, reg code.Reg, val Value) {

--- a/runtime/termination.go
+++ b/runtime/termination.go
@@ -92,6 +92,10 @@ func (c *Termination) DebugInfo() *DebugInfo {
 	return c.parent.DebugInfo()
 }
 
+func (c *Termination) Cleanup(t *Thread, err *Error) *Error {
+	return err
+}
+
 // Get returns the n-th arg pushed to the termination.
 func (c *Termination) Get(n int) Value {
 	if n >= c.pushIndex {

--- a/runtime/thread.go
+++ b/runtime/thread.go
@@ -16,9 +16,9 @@ const (
 )
 
 type valuesError struct {
-	args     []Value
-	err      *Error
-	quotaErr *ContextTerminationError
+	args  []Value
+	err   *Error
+	extra interface{}
 }
 
 // A Thread is a lua thread.
@@ -100,28 +100,36 @@ func (t *Thread) RunContinuation(c Cont) (err *Error) {
 	return
 }
 
+// This is to be able to close a suspended coroutine without completing it, but
+// still allow cleaning up the to-be-closed variables.  If this is put on the
+// resume channel of a running thread, yield will cause a panic in the goroutine
+// and that will be caught in the defer() clause below.
+type threadClose struct{}
+
 // Start starts the thread in a goroutine, giving it the callable c to run.  the
 // t.Resume() method needs to be called to provide arguments to the callable.
 func (t *Thread) Start(c Callable) {
 	t.RequireBytes(2 << 10) // A goroutine starts off with 2k stack
 	go func() {
 		var (
-			args     []Value
-			err      *Error
-			quotaErr *ContextTerminationError
+			args []Value
+			err  *Error
 		)
 		// If there was a panic due to an exceeded quota, we need to end the
 		// thread and propagate that panic to the calling thread
 		defer func() {
-			if r := recover(); r != nil {
-				quotaErr = new(ContextTerminationError)
-				var ok bool
-				*quotaErr, ok = r.(ContextTerminationError)
-				if !ok {
+			r := recover()
+			if r != nil {
+				switch r.(type) {
+				case ContextTerminationError:
+				case threadClose:
+					// This means we want to close the coroutine, so no panic!
+					r = nil
+				default:
 					panic(r)
 				}
 			}
-			t.end(args, err, quotaErr)
+			t.end(args, err, r)
 		}()
 		args, err = t.getResumeValues()
 		if err == nil {
@@ -162,6 +170,32 @@ func (t *Thread) Resume(caller *Thread, args []Value) ([]Value, *Error) {
 	return caller.getResumeValues()
 }
 
+// Resume execution of a suspended thread.  Its status switches to
+// running while its caller's status switches to suspended.
+func (t *Thread) Close(caller *Thread) *Error {
+	t.mux.Lock()
+	if t.status != ThreadSuspended {
+		t.mux.Unlock()
+		switch t.status {
+		case ThreadDead:
+			return NewErrorS("cannot close dead thread")
+		default:
+			return NewErrorS("cannot close running thread")
+		}
+	}
+	caller.mux.Lock()
+	if caller.status != ThreadOK {
+		panic("Caller of thread to close is not running")
+	}
+	t.caller = caller
+	t.status = ThreadOK
+	t.mux.Unlock()
+	caller.mux.Unlock()
+	t.sendResumeValues(nil, nil, threadClose{})
+	_, err := caller.getResumeValues()
+	return err
+}
+
 // Yield to the caller thread.  The yielding thread's status switches
 // to suspended while the caller's status switches back to running.
 func (t *Thread) Yield(args []Value) ([]Value, *Error) {
@@ -186,7 +220,7 @@ func (t *Thread) Yield(args []Value) ([]Value, *Error) {
 	return t.getResumeValues()
 }
 
-func (t *Thread) end(args []Value, err *Error, quotaErr *ContextTerminationError) {
+func (t *Thread) end(args []Value, err *Error, extra interface{}) {
 	caller := t.caller
 	t.mux.Lock()
 	caller.mux.Lock()
@@ -197,12 +231,14 @@ func (t *Thread) end(args []Value, err *Error, quotaErr *ContextTerminationError
 		panic("Called Thread.end on a non-running thread")
 	case caller.status != ThreadOK:
 		panic("Caller thread of ending thread is not OK")
-	default:
-		close(t.resumeCh)
-		t.status = ThreadDead
-		t.caller = nil
 	}
-	caller.sendResumeValues(args, err, quotaErr)
+	close(t.resumeCh)
+	t.status = ThreadDead
+	t.caller = nil
+	for c := t.CurrentCont(); c != nil; c = c.Next() {
+		err = c.Cleanup(caller, err)
+	}
+	caller.sendResumeValues(args, err, extra)
 	t.ReleaseBytes(2 << 10) // The goroutine will terminate after this
 }
 
@@ -213,14 +249,14 @@ func (t *Thread) call(c Callable, args []Value, next Cont) *Error {
 
 func (t *Thread) getResumeValues() ([]Value, *Error) {
 	res := <-t.resumeCh
-	if res.quotaErr != nil {
-		panic(*res.quotaErr)
+	if res.extra != nil {
+		panic(res.extra)
 	}
 	return res.args, res.err
 }
 
-func (t *Thread) sendResumeValues(args []Value, err *Error, quotaErr *ContextTerminationError) {
-	t.resumeCh <- valuesError{args, err, quotaErr}
+func (t *Thread) sendResumeValues(args []Value, err *Error, extra interface{}) {
+	t.resumeCh <- valuesError{args, err, extra}
 }
 
 type messageHandlerCont struct {

--- a/runtime/thread_test.go
+++ b/runtime/thread_test.go
@@ -91,9 +91,9 @@ func TestThread_Yield(t *testing.T) {
 
 func TestThread_end(t *testing.T) {
 	type args struct {
-		args     []Value
-		err      *Error
-		quotaErr *ContextTerminationError
+		args  []Value
+		err   *Error
+		extra interface{}
 	}
 	quotaErr := ContextTerminationError{message: "boo!"}
 	tests := []struct {
@@ -132,7 +132,7 @@ func TestThread_end(t *testing.T) {
 				resumeCh: make(chan valuesError),
 			},
 			args: args{
-				quotaErr: &quotaErr,
+				extra: quotaErr,
 			},
 			wantPanic: quotaErr,
 		},
@@ -144,12 +144,12 @@ func TestThread_end(t *testing.T) {
 			gotPanic := func() (res interface{}) {
 				defer func() { res = recover() }()
 				caller := th.caller // The caller is removed when th is killed
-				th.end(tt.args.args, tt.args.err, tt.args.quotaErr)
+				th.end(tt.args.args, tt.args.err, tt.args.extra)
 				_, _ = caller.getResumeValues()
 				return
 			}()
 			if gotPanic != tt.wantPanic {
-				t.Errorf("Thread.end() panic got %v, want %v", gotPanic, tt.wantPanic)
+				t.Errorf("Thread.end() panic got %#v, want %#v", gotPanic, tt.wantPanic)
 			}
 		})
 	}


### PR DESCRIPTION
To-be-closed variables are a new feature of Lua 5.4: https://www.lua.org/manual/5.4/manual.html#3.3.8

See added tests in `locals.lua` for working examples and `thread.lua` for coroutine tests, including the use of `coroutine.close()`.

The feature is under-specified somewhat in the Lua docs.

Need to support
- [x] errors
- [x] coroutines (that includes implementing coroutine.close() which allows closing a suspended coroutine without completing it, cleaning up all pending to-be-closed variables)

## Approach

I try to give a succinct explanation of the implementation approach.

### Height of a lexical scope

During AST -> IR compilation, a **height** is assigned to each lexical scope.  If L2 is a lexical scope with parent L1, then

    height(L2) = height(L1) + n, where n is the number of to-be-closed variables that L2 defines

If L is a root lexical scope (i.e. it is the outermost block in a function body) then

    height(L) = 0

### Code generation

There are 2 new opcodes:
- `clpush <reg>`: push the contents of `<reg>` onto the close stack
- `cltrunc h`: truncate the close stack to height `h` (`h` is encoded in the opcode and must be known at compile time)

This is how the opcodes are inserted
- Whenever a to-be-closed varable is defined (`local x <close> = val`), a `clpush r1` instruction is emitted, where `r1` is the register containing `val`.
- Whenever a lexical scope L is exited, a `cltrunc h` instruction is emitted where `h` is the height of the parent scope of `L`
- Whenever a Jump is emitted, just before the jump is emitted a `cltrunc h` instruction is emitted where `h` is the height of the lexical scope of the jump destination.

### Runtime

There are two aspects to the runtime machinery - normal execution of Lua continutaions and error handling

#### Normal execution of Lua continuations

Each Lua continuation maintains a **close stack**, which is a stack of Lua values. It starts empty and is modified as follows
- `clpush <reg>` pushes the value of `<reg>` on top of the close stack
- `cltrunc h` pops values from the top of the close stack and executes their `__close` metamethod until the height of the close stack is at most `h`.
- When returning from a Lua function (return OR tail-call), a `cltrunc 0` instruction is executed.

#### Error handling

If there is an error, then all close stacks in the "call stack" should be called until the error is caught.  This is achieve by adding a `Cleanup()` method to the `runtime.Cont` interface, which must be implemented by each continuation type.   The runtime loop will call those in turn down the call stack when an error is encountered.  For a Lua continuation, `Cleanup()` is roughly equivalent to `cltrunc 0`.




