### PR TITLE
Implement Lua 5.4 pointer format specifier

### DIFF
--- a/lib/stringlib/format.go
+++ b/lib/stringlib/format.go
@@ -143,7 +143,7 @@ OuterLoop:
 				case 'p':
 					// Pointer address, new in Lua 5.4
 					switch v := values[j]; v.Type() {
-					case rt.BoolType, rt.FloatType, rt.IntType:
+					case rt.BoolType, rt.FloatType, rt.IntType, rt.NilType:
 						outFormat[i] = 's'
 						arg = "(null)"
 					case rt.StringType:

--- a/lib/stringlib/lua/stringlib.lua
+++ b/lib/stringlib/lua/stringlib.lua
@@ -300,6 +300,8 @@ do
     --> =(null)
     pf("%p", 2.5)
     --> =(null)
+    pf("%p", nil)
+    --> =(null)
 
     pf("=%p=", "hello")
     --> ~=0x[0-9a-f]+=

--- a/lib/stringlib/lua/stringlib.lua
+++ b/lib/stringlib/lua/stringlib.lua
@@ -281,6 +281,59 @@ do
     errf(321)
     --> ~must be a string
 
+    -- New in Lua 5.4: %p formatting
+
+    local function ps(x) return string.format("%p", x) end
+
+    local t = {}
+    pf("=%p=", t)
+    --> ~=0x[0-9a-f]+=
+
+    local tp = ps(t)
+    t.x = "something"
+    print(ps(t) == tp)
+    --> =true
+
+    pf("%p", 1)
+    --> =(null)
+    pf("%p", true)
+    --> =(null)
+    pf("%p", 2.5)
+    --> =(null)
+
+    pf("=%p=", "hello")
+    --> ~=0x[0-9a-f]+=
+
+    pf("=%p=", print)
+    --> ~=0x[0-9a-f]+=
+
+    print(ps(print) == ps(print))
+    --> =true
+
+    pf("=%p=", coroutine.running())
+    --> ~=0x[0-9a-f]+=
+
+    print(ps(coroutine.running()) == ps(coroutine.running()))
+    --> =true
+
+    pf("=%p=", io.stdout)
+    --> ~=0x[0-9a-f]+=
+
+    print(ps(io.stdout) == ps(io.stdout))
+    --> =true
+
+    print(ps(io.stdout) == ps(io.stdin))
+    --> =false
+
+    pf("=%p=", pf)
+    --> ~=0x[0-9a-f]+=
+
+    print(ps(pf) == ps(pf))
+    --> =true
+
+    print(ps(pf) == ps(ps))
+    --> =false
+
 end
 
 do


### PR DESCRIPTION
`string.format("%p", arg)` format the address of arg unless arg is a scalar (boolean / number) or nil.