### PR TITLE
Implement warning system (Lua 5.4)

### DIFF
--- a/lib/base/base.go
+++ b/lib/base/base.go
@@ -43,6 +43,7 @@ func Load(r *rt.Runtime) (rt.Value, func()) {
 		r.SetEnvGoFunc(env, "tonumber", tonumber, 2, false),
 		r.SetEnvGoFunc(env, "tostring", tostring, 1, false),
 		r.SetEnvGoFunc(env, "type", typeString, 1, false),
+		r.SetEnvGoFunc(env, "warn", warn, 0, true), // Added in Lua 5.4
 		r.SetEnvGoFunc(env, "xpcall", xpcall, 2, true),
 	)
 	rt.SolemnlyDeclareCompliance(

--- a/lib/base/lua/warn.lua
+++ b/lib/base/lua/warn.lua
@@ -1,0 +1,26 @@
+-- off by default
+warn("discarded warning")
+
+warn("@on")
+
+warn("a warning")
+--> =Test warning: a warning
+
+warn("this", 12, 9.5)
+--> =Test warning: this129.5
+
+warn("some", "@on", "other", "@off")
+--> =Test warning: some@onother@off
+
+warn("@off")
+
+warn("discarded")
+print("hello")
+--> =hello
+
+print(pcall(warn))
+--> ~false\t.*value needed
+
+print(pcall(warn, {}))
+--> ~false\t.*string expected
+

--- a/lib/base/warn.go
+++ b/lib/base/warn.go
@@ -1,0 +1,20 @@
+package base
+
+import rt "github.com/arnodel/golua/runtime"
+
+func warn(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
+	args := c.Etc()
+	if len(args) == 0 {
+		return nil, rt.NewErrorS("bad argument #1 (value needed)")
+	}
+	msgs := make([]string, len(args))
+	for i, v := range args {
+		s, ok := v.ToString()
+		if !ok {
+			return nil, rt.NewErrorF("bad argument #%d (string expected)", i+1)
+		}
+		msgs[i] = s
+	}
+	t.Warn(msgs...)
+	return c.Next(), nil
+}

--- a/luatesting/runtests.go
+++ b/luatesting/runtests.go
@@ -33,6 +33,7 @@ func RunSource(r *runtime.Runtime, source []byte) {
 func RunLuaTest(source []byte, setup func(*runtime.Runtime) func()) error {
 	outputBuf := new(bytes.Buffer)
 	r := runtime.New(outputBuf)
+	r.SetWarner(runtime.NewLogWarner(outputBuf, "Test warning: "))
 	if setup != nil {
 		cleanup := setup(r)
 		defer cleanup()

--- a/runtime/lua/warn.lua
+++ b/runtime/lua/warn.lua
@@ -1,0 +1,25 @@
+-- off by default
+warn("discarded warning")
+
+warn("@on")
+
+warn("a warning")
+--> =Test warning: a warning
+
+warn("this", 12, 9.5)
+--> =Test warning: this129.5
+
+warn("some", "@on", "other", "@off")
+--> =Test warning: some@onother@off
+
+warn("@off")
+
+warn("discarded")
+print("hello")
+--> =hello
+
+print(pcall(warn))
+--> ~false\t.*value needed
+
+print(pcall(warn, {}))
+--> ~false\t.*string expected

--- a/runtime/warn.go
+++ b/runtime/warn.go
@@ -1,0 +1,50 @@
+package runtime
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// Warner is the interface for the Lua warning system.  The Warn function emits
+// warning, when called with one argument, if the argument starts with '@' then
+// the message is a control message.  These messages are not emitted but control
+// the behaviour of the Warner instance.
+type Warner interface {
+	Warn(msgs ...string)
+}
+
+// The default Warner type.  It logs messages to a given io.Writer.  Note that
+// it is off by default.  Issue Warn("@on") to turn it on.
+type LogWarner struct {
+	on   bool
+	dest io.Writer
+	pfx  string
+}
+
+var _ Warner = (*LogWarner)(nil)
+
+// NewLogWarner returns a new LogWarner that will write to dest with the given
+// prefix.
+func NewLogWarner(dest io.Writer, pfx string) *LogWarner {
+	return &LogWarner{dest: dest, pfx: pfx}
+}
+
+// Warn concatenates its arguments and emits a warning message (written to
+// dest).  It understands two control messages: "@on" and "@off", with the
+// obvious meaning.
+func (w *LogWarner) Warn(msgs ...string) {
+	if len(msgs) == 1 && len(msgs[0]) > 0 && msgs[0][0] == '@' {
+		// Control message
+		switch msgs[0] {
+		case "@on":
+			w.on = true
+		case "@off":
+			w.on = false
+		}
+		return
+	}
+	if w.on {
+		fmt.Fprintf(w.dest, "%s%s\n", w.pfx, strings.Join(msgs, ""))
+	}
+}


### PR DESCRIPTION
This implements that Go API for the warning system

- runtime.Warner interface
- runtime.LogWarner type implementing runtime.Warner, used as the default warner
- (*Runtime).SetWarner() and (*Runtime).Warn()
- the base library warn() Lua function

There are tests in runtime/lua/warn.lua and lib/base/lua/warn.lua
