### PR TITLE
Lua 5.4 no inferred le metamethod

### DIFF
--- a/ast/localstat.go
+++ b/ast/localstat.go
@@ -41,24 +41,34 @@ func (s LocalStat) HWrite(w HWriter) {
 	w.Dedent()
 }
 
+// LocalAttrib is the type of a local name attrib
+type LocalAttrib uint8
+
+// Valid values for LocalAttrib
+const (
+	NoAttrib    LocalAttrib = iota
+	ConstAttrib             // <const>, introduced in Lua 5.4
+	CloseAttrib             // <close>, introduced in Lua 5.4
+)
+
+// A NameAttrib is a name introduce by a local definition, together with an
+// optional attribute (in Lua 5.4 that is 'close' or 'const').
 type NameAttrib struct {
 	Location
 	Name   Name
-	Attrib *Name
+	Attrib LocalAttrib
 }
 
-func NewNameAttrib(name Name, attrib *Name) NameAttrib {
+// NewNameAttrib returns a new NameAttribe for the given name and attrib.
+func NewNameAttrib(name Name, attribName *Name, attrib LocalAttrib) NameAttrib {
 	loc := name.Location
-	if attrib != nil {
-		loc = MergeLocations(loc, attrib)
+	if attribName != nil {
+		loc = MergeLocations(loc, attribName)
+
 	}
 	return NameAttrib{
 		Location: loc,
 		Name:     name,
 		Attrib:   attrib,
 	}
-}
-
-func (na NameAttrib) IsConst() bool {
-	return na.Attrib != nil && na.Attrib.Val == "const"
 }

--- a/ast/localstat.go
+++ b/ast/localstat.go
@@ -4,20 +4,20 @@ package ast
 // list of local variables.
 type LocalStat struct {
 	Location
-	Names  []Name
-	Values []ExpNode
+	NameAttribs []NameAttrib
+	Values      []ExpNode
 }
 
 var _ Stat = LocalStat{}
 
 // NewLocalStat returns a LocalStat instance defining the given names with the
 // given values.
-func NewLocalStat(names []Name, values []ExpNode) LocalStat {
-	loc := MergeLocations(names[0], names[len(names)-1])
+func NewLocalStat(nameAttribs []NameAttrib, values []ExpNode) LocalStat {
+	loc := MergeLocations(nameAttribs[0], nameAttribs[len(nameAttribs)-1])
 	if len(values) > 0 {
 		loc = MergeLocations(loc, values[len(values)-1])
 	}
-	return LocalStat{Location: loc, Names: names, Values: values}
+	return LocalStat{Location: loc, NameAttribs: nameAttribs, Values: values}
 }
 
 // ProcessStat uses the given StatProcessor to process the receiver.
@@ -29,9 +29,9 @@ func (s LocalStat) ProcessStat(p StatProcessor) {
 func (s LocalStat) HWrite(w HWriter) {
 	w.Writef("local")
 	w.Indent()
-	for i, name := range s.Names {
+	for i, nameAttrib := range s.NameAttribs {
 		w.Next()
-		w.Writef("name_%d: %s", i, name)
+		w.Writef("name_%d: %s", i, nameAttrib)
 	}
 	for i, val := range s.Values {
 		w.Next()
@@ -39,4 +39,26 @@ func (s LocalStat) HWrite(w HWriter) {
 		val.HWrite(w)
 	}
 	w.Dedent()
+}
+
+type NameAttrib struct {
+	Location
+	Name   Name
+	Attrib *Name
+}
+
+func NewNameAttrib(name Name, attrib *Name) NameAttrib {
+	loc := name.Location
+	if attrib != nil {
+		loc = MergeLocations(loc, attrib)
+	}
+	return NameAttrib{
+		Location: loc,
+		Name:     name,
+		Attrib:   attrib,
+	}
+}
+
+func (na NameAttrib) IsConst() bool {
+	return na.Attrib != nil && na.Attrib.Val == "const"
 }

--- a/astcomp/compstat.go
+++ b/astcomp/compstat.go
@@ -59,7 +59,7 @@ func (c *compiler) ProcessForInStat(s ast.ForInStat) {
 
 	nameAttribs := make([]ast.NameAttrib, len(s.Vars))
 	for i, name := range s.Vars {
-		nameAttribs[i] = ast.NewNameAttrib(name, nil)
+		nameAttribs[i] = ast.NewNameAttrib(name, nil, ast.NoAttrib)
 	}
 	c.CompileStat(ast.LocalStat{
 		NameAttribs: nameAttribs,
@@ -265,8 +265,16 @@ func (c *compiler) ProcessLocalStat(s ast.LocalStat) {
 	for i, reg := range localRegs {
 		c.ReleaseRegister(reg)
 		c.DeclareLocal(ir.Name(s.NameAttribs[i].Name.Val), reg)
-		if s.NameAttribs[i].IsConst() {
+		switch s.NameAttribs[i].Attrib {
+		case ast.NoAttrib:
+			// Nothing to do
+		case ast.ConstAttrib:
 			c.MarkConstantReg(reg)
+		case ast.CloseAttrib:
+			c.MarkConstantReg(reg)
+			c.PushCloseAction(reg)
+		default:
+			panic(compilerBug{})
 		}
 	}
 }

--- a/astcomp/compvar.go
+++ b/astcomp/compvar.go
@@ -1,6 +1,8 @@
 package astcomp
 
 import (
+	"fmt"
+
 	"github.com/arnodel/golua/ast"
 	"github.com/arnodel/golua/ir"
 )
@@ -37,6 +39,12 @@ func (c *assignCompiler) ProcessIndexExpVar(e ast.IndexExp) {
 func (c *assignCompiler) ProcessNameVar(n ast.Name) {
 	reg, ok := c.GetRegister(ir.Name(n.Val))
 	if ok {
+		if c.IsConstantReg(reg) {
+			panic(Error{
+				Where:   n,
+				Message: fmt.Sprintf("attempt to reassign constant variable '%s'", n.Val),
+			})
+		}
 		c.assigns = append(c.assigns, func(src ir.Register) {
 			c.emitMove(n, reg, src)
 		})

--- a/code/instructions.go
+++ b/code/instructions.go
@@ -130,14 +130,32 @@ func JumpIfNot(j Offset, r Reg) Opcode {
 //
 // r must contain a continuation that is ready to be called.
 func Call(r Reg) Opcode {
-	return mkType5(Off, OpCall, r, 0)
+	return mkType5(Off, OpCall, r, Offset(0))
 }
 
 // TailCall encodes tailcall r
 //
 // r must contain a continuation that is ready to be called.
 func TailCall(r Reg) Opcode {
-	return mkType5(On, OpCall, r, 0)
+	return mkType5(On, OpCall, r, Offset(0))
+}
+
+// ClTrunc encodes cltrunc h
+//
+// It truncates the close stack to the given height.  Each value on the close
+// stack which is removed should either be nil or false, or be a value with a
+// "__close" metamethod, in which case this metamethod is called.  This opcode
+// is introduced to support Lua 5.4's "to-be-closed" variables.
+func ClTrunc(h uint16) Opcode {
+	return mkType5(Off, OpClStack, Reg{}, ClStackOffset(h))
+}
+
+// ClPush encodes clpush r
+//
+// r should contain either nil, false, or a value with a "__close" metamethod.
+// This opcode is introduced to support Lua 5.4's "to-be-closed" variables.
+func ClPush(r Reg) Opcode {
+	return mkType5(On, OpClStack, r, ClStackOffset(0))
 }
 
 // Upval encodes upval r1, r2

--- a/code/opcodes.go
+++ b/code/opcodes.go
@@ -342,6 +342,7 @@ const (
 	OpCall JumpOp = iota
 	OpJump
 	OpJumpIf
+	OpClStack // Operate on the Close Stack
 )
 
 // encodeJ encodes a jump type into and opcode.
@@ -356,6 +357,17 @@ func (d Offset) encodeD() Opcode {
 	return Opcode(uint16(d))
 }
 
+// ClStackOffset is an offset from the bottom of the close stack
+type ClStackOffset uint16
+
+func (d ClStackOffset) encodeD() Opcode {
+	return Opcode(d)
+}
+
+type encoderToD interface {
+	encodeD() Opcode
+}
+
 // GetJ decodes the JumpOp from this opcode.
 func (c Opcode) GetJ() JumpOp {
 	return JumpOp(c.getYorJ())
@@ -366,12 +378,16 @@ func (c Opcode) GetOffset() Offset {
 	return Offset(uint16(c))
 }
 
+func (c Opcode) GetClStackOffset() ClStackOffset {
+	return ClStackOffset(uint16(c))
+}
+
 // SetOffset returns a copy of the opcode with the given offset.
 func (c Opcode) SetOffset(n Offset) Opcode {
 	return c&0xffff0000 | n.encodeD()
 }
 
-func mkType5(f Flag, op JumpOp, rA Reg, k Offset) Opcode {
+func mkType5(f Flag, op JumpOp, rA Reg, k encoderToD) Opcode {
 	return Type5Pfx | f.encodeF() | op.encodeJ() | rA.toA() | k.encodeD()
 }
 
@@ -637,6 +653,12 @@ func (c Opcode) Disassemble(d OpcodeDisassembler, i int) string {
 				instr = "tailcall"
 			}
 			return fmt.Sprintf("%s %s", instr, rA)
+		case OpClStack:
+			if c.GetF() {
+				return fmt.Sprintf("clpush %s", rA)
+			} else {
+				return fmt.Sprintf("cltrunc %d", c.GetClStackOffset())
+			}
 		default:
 			return "???"
 		}

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -9,8 +9,9 @@ import (
 type Name string
 
 type RegData struct {
-	IsCell   bool
-	refCount int
+	IsCell     bool
+	IsConstant bool
+	refCount   int
 }
 
 const regHasUpvalue uint = 1
@@ -181,6 +182,14 @@ func (c *CodeBuilder) EmitJump(lblName Name, line int) bool {
 func (c *CodeBuilder) DeclareLocal(name Name, reg Register) {
 	c.TakeRegister(reg)
 	c.context.addToTop(name, reg)
+}
+
+func (c *CodeBuilder) MarkConstantReg(reg Register) {
+	c.registers[reg].IsConstant = true
+}
+
+func (c *CodeBuilder) IsConstantReg(reg Register) bool {
+	return c.registers[reg].IsConstant
 }
 
 func (c *CodeBuilder) EmitNoLine(instr Instruction) {

--- a/ir/context.go
+++ b/ir/context.go
@@ -3,8 +3,9 @@ package ir
 import "fmt"
 
 type lexicalScope struct {
-	reg   map[Name]taggedReg
-	label map[Name]Label
+	reg    map[Name]taggedReg // maps variable names to registers
+	label  map[Name]Label     // maps label names to labels
+	height int                // This is the height of the close stack in this scope
 }
 
 type taggedReg struct {
@@ -78,12 +79,22 @@ func (c lexicalContext) addLabel(name Name, label Label) (ok bool) {
 	return
 }
 
+// addHeight increases the height of the topmost lexical scope in this context.
+func (c lexicalContext) addHeight(h int) (ok bool) {
+	ok = len(c) > 0
+	if ok {
+		c[len(c)-1].height += h
+	}
+	return ok
+}
+
 // pushNew returns a new LexicalContext that extends the receive with a new
 // blank lexical scope.
 func (c lexicalContext) pushNew() lexicalContext {
 	return append(c, lexicalScope{
-		reg:   make(map[Name]taggedReg),
-		label: make(map[Name]Label),
+		reg:    make(map[Name]taggedReg),
+		label:  make(map[Name]Label),
+		height: c.top().height,
 	})
 }
 

--- a/ir/instructions.go
+++ b/ir/instructions.go
@@ -41,6 +41,8 @@ type InstrProcessor interface {
 	ProcessReceiveEtcInstr(ReceiveEtc)
 	ProcessEtcLookupInstr(EtcLookup)
 	ProcessFillTableInstr(FillTable)
+	ProcessTruncateCloseStackInstr(TruncateCloseStack)
+	ProcessPushCloseStackInstr(PushCloseStack)
 
 	// These are hints that a register is needed or no longer needed.
 	ProcessTakeRegisterInstr(TakeRegister)
@@ -416,6 +418,38 @@ func (f FillTable) String() string {
 // ProcessInstr makes the InstrProcessor process this instruction.
 func (f FillTable) ProcessInstr(p InstrProcessor) {
 	p.ProcessFillTableInstr(f)
+}
+
+// TruncateCloseStack truncates the close stack to Height (which should be >=
+// 0).  This instruction was introduced to support to-be-closed variables which
+// are part of Lua 5.4
+type TruncateCloseStack struct {
+	Height int
+}
+
+func (t TruncateCloseStack) String() string {
+	return fmt.Sprintf("trunc close stack to %d", t.Height)
+}
+
+// ProcessInstr makes the InstrProcessor process this instruction.
+func (t TruncateCloseStack) ProcessInstr(p InstrProcessor) {
+	p.ProcessTruncateCloseStackInstr(t)
+}
+
+// PushCloseStack truncates pushes the value Src to the close stack.  This
+// instruction was introduced to support to-be-closed variables which are part
+// of Lua 5.4
+type PushCloseStack struct {
+	Src Register
+}
+
+func (i PushCloseStack) String() string {
+	return fmt.Sprintf("push %s to close stack", i.Src)
+}
+
+// ProcessInstr makes the InstrProcessor process this instruction.
+func (i PushCloseStack) ProcessInstr(p InstrProcessor) {
+	p.ProcessPushCloseStackInstr(i)
 }
 
 // TakeRegister is not a real instruction.  It is a hint to the next stage that

--- a/ircomp/compinstr.go
+++ b/ircomp/compinstr.go
@@ -214,6 +214,19 @@ func (ic instrCompiler) ProcessFillTableInstr(f ir.FillTable) {
 	ic.Emit(code.FillTable(ic.codeReg(f.Dst), ic.codeReg(f.Etc), f.Idx))
 }
 
+// ProcessTruncateCloseStackInstr compiles a TruncateCloseStack instruction.
+func (ic instrCompiler) ProcessTruncateCloseStackInstr(t ir.TruncateCloseStack) {
+	if t.Height < 0 || t.Height >= 65536 {
+		panic("close stack height out of range")
+	}
+	ic.Emit(code.ClTrunc(uint16(t.Height)))
+}
+
+// ProcessPushCloseStackInstr compiles a PushCloseStack instruction.
+func (ic instrCompiler) ProcessPushCloseStackInstr(p ir.PushCloseStack) {
+	ic.Emit(code.ClPush(ic.codeReg(p.Src)))
+}
+
 func (ic instrCompiler) ProcessTakeRegisterInstr(t ir.TakeRegister) {
 	ic.takeRegister(t.Reg)
 

--- a/lib/coroutine/lua/coroutine.lua
+++ b/lib/coroutine/lua/coroutine.lua
@@ -89,3 +89,36 @@ do
     print(fib(), fib(), fib(), fib(), fib())
     --> =0	1	1	2	3
 end
+
+-- Test coroutine.close() (5.4)
+do
+    print(pcall(coroutine.close))
+    --> ~false\t.*value needed
+
+    print(pcall(coroutine.close, 1))
+    --> ~false\t.*must be a thread
+
+    print(pcall(coroutine.close, coroutine.running()))
+    --> ~true\tfalse\t.*cannot close running thread
+
+    local co = coroutine.create(function()
+        coroutine.yield()
+    end)
+
+    coroutine.resume(co)
+    print(coroutine.close(co))
+    --> =true
+    print(coroutine.status(co))
+    --> =dead
+    local co = coroutine.create(function()
+        local x <close> = {}
+        setmetatable(x, {__close=function() error("ERR") end})
+        coroutine.yield()
+    end)
+    coroutine.resume(co)
+    pcall(function() print(coroutine.close(co)) end)
+    --> ~false\t.*ERR
+
+    print(coroutine.status(co))
+    --> =dead
+end

--- a/notes/to-be-closed.md
+++ b/notes/to-be-closed.md
@@ -1,0 +1,68 @@
+# Implementation notes for to-be-closed variables
+
+This is a feature introduced in Lua 5.4.  See
+https://www.lua.org/manual/5.4/manual.html#3.3.8
+
+## Approach
+
+I try to give a succinct explanation of the implementation approach.
+
+### Height of a lexical scope
+
+During AST -> IR compilation, a **height** is assigned to each lexical scope.
+If L2 is a lexical scope with parent L1, then
+
+    height(L2) = height(L1) + n, where n is the number of to-be-closed variables that L2 defines
+
+If L is a root lexical scope (i.e. it is the outermost block in a function body)
+then
+
+    height(L) = 0
+
+### Code generation
+
+There are 2 new opcodes:
+- `clpush <reg>`: push the contents of `<reg>` onto the close stack
+- `cltrunc h`: truncate the close stack to height `h` (`h` is encoded in the
+  opcode and must be known at compile time)
+
+This is how the opcodes are inserted
+- Whenever a to-be-closed varable is defined (`local x <close> = val`), a
+  `clpush r1` instruction is emitted, where `r1` is the register containing
+  `val`.
+- Whenever a lexical scope L is exited, a `cltrunc h` instruction is emitted where `h` is the height of the parent scope of `L`
+- Whenever a Jump is emitted, just before the jump is emitted a `cltrunc h`
+  instruction is emitted where `h` is the height of the lexical scope of the
+  jump destination.
+
+### Runtime
+
+There are two aspects to the runtime machinery - normal execution of Lua
+continutaions and error handling
+
+#### Normal execution of Lua continuations
+
+Each Lua continuation maintains a **close stack**, which is a stack of Lua
+values. It starts empty and is modified as follows
+- `clpush <reg>` pushes the value of `<reg>` on top of the close stack
+- `cltrunc h` pops values from the top of the close stack and executes their
+  `__close` metamethod until the height of the close stack is at most `h`.
+- When returning from a Lua function (return OR tail-call), a `cltrunc 0`
+  instruction is executed.
+
+#### Error handling
+
+If there is an error, then all close stacks in the "call stack" should be called
+until the error is caught.  This is achieve by adding a `Cleanup()` method to
+the `runtime.Cont` interface, which must be implemented by each continuation
+type.   The runtime loop will call those in turn down the call stack when an
+error is encountered.  For a Lua continuation, `Cleanup()` is roughly equivalent
+to `cltrunc 0`.
+
+#### Coroutines
+
+Lua 5.4 adds a `coroutine.close()` function that allows stopping a suspended
+coroutine but executing all pending to-be-closed variables.  Given the approach
+above this is simply a matter of executing the `Cleanup()` method on the
+suspended thread's current continuation and its successors.
+

--- a/parsing/parser.go
+++ b/parsing/parser.go
@@ -242,17 +242,17 @@ func (p *Parser) Local(*token.Token) (ast.Stat, *token.Token) {
 		return ast.NewLocalFunctionStat(name, fx), t
 	}
 	// local namelist ['=' explist]
-	name, t := p.Name(t)
-	names := []ast.Name{name}
+	nameAttrib, t := p.NameAttrib(t)
+	nameAttribs := []ast.NameAttrib{nameAttrib}
 	for t.Type == token.SgComma {
-		name, t = p.Name(p.Scan())
-		names = append(names, name)
+		nameAttrib, t = p.NameAttrib(p.Scan())
+		nameAttribs = append(nameAttribs, nameAttrib)
 	}
 	var values []ast.ExpNode
 	if t.Type == token.SgAssign {
 		values, t = p.ExpList(p.Scan())
 	}
-	return ast.NewLocalStat(names, values), t
+	return ast.NewLocalStat(nameAttribs, values), t
 }
 
 // FunctionStat parses a function definition statement. It assumes that t is the
@@ -606,6 +606,16 @@ func (p *Parser) Field(t *token.Token) (ast.TableField, *token.Token) {
 func (p *Parser) Name(t *token.Token) (ast.Name, *token.Token) {
 	expectIdent(t)
 	return ast.NewName(t), p.Scan()
+}
+
+func (p *Parser) NameAttrib(t *token.Token) (ast.NameAttrib, *token.Token) {
+	name, t := p.Name(t)
+	if t.Type != token.SgLess {
+		return ast.NameAttrib{Name: name}, t
+	}
+	attrib, t := p.Name(p.Scan())
+	expectType(t, token.SgGreater, "'>'")
+	return ast.NameAttrib{Name: name, Attrib: &attrib}, p.Scan()
 }
 
 func expectIdent(t *token.Token) {

--- a/parsing/parser_test.go
+++ b/parsing/parser_test.go
@@ -37,6 +37,13 @@ func tok(tp token.Type, lit string) *token.Token {
 func name(s string) ast.Name {
 	return ast.Name{Val: s}
 }
+func nameAttrib(s string, attrib ...string) ast.NameAttrib {
+	var attribName *ast.Name
+	if len(attrib) > 0 {
+		attribName = &ast.Name{Val: attrib[0]}
+	}
+	return ast.NameAttrib{Name: name(s), Attrib: attribName}
+}
 
 func str(s string) ast.String {
 	return ast.String{Val: []byte(s)}
@@ -991,21 +998,21 @@ func TestParser_Local(t *testing.T) {
 		{
 			name:  "local single variable declaration with no value",
 			input: "local x z",
-			want:  ast.LocalStat{Names: []ast.Name{name("x")}},
+			want:  ast.LocalStat{NameAttribs: []ast.NameAttrib{nameAttrib("x")}},
 			want1: tok(token.IDENT, "z"),
 		},
 		{
 			name:  "local 3 variables declaration with no value",
 			input: "local x, y, z",
-			want:  ast.LocalStat{Names: []ast.Name{name("x"), name("y"), name("z")}},
+			want:  ast.LocalStat{NameAttribs: []ast.NameAttrib{nameAttrib("x"), nameAttrib("y"), nameAttrib("z")}},
 			want1: tok(token.EOF, ""),
 		},
 		{
 			name:  "local 3 variables declaration with 1 value",
 			input: "local x, y, z = 123",
 			want: ast.LocalStat{
-				Names:  []ast.Name{name("x"), name("y"), name("z")},
-				Values: []ast.ExpNode{ast.NewInt(123)},
+				NameAttribs: []ast.NameAttrib{nameAttrib("x"), nameAttrib("y"), nameAttrib("z")},
+				Values:      []ast.ExpNode{ast.NewInt(123)},
 			},
 			want1: tok(token.EOF, ""),
 		},
@@ -1013,8 +1020,17 @@ func TestParser_Local(t *testing.T) {
 			name:  "local 2 variables declaration with 3 value",
 			input: `local x, y = 123, "a", 'b'`,
 			want: ast.LocalStat{
-				Names:  []ast.Name{name("x"), name("y")},
-				Values: []ast.ExpNode{ast.NewInt(123), str("a"), str("b")},
+				NameAttribs: []ast.NameAttrib{nameAttrib("x"), nameAttrib("y")},
+				Values:      []ast.ExpNode{ast.NewInt(123), str("a"), str("b")},
+			},
+			want1: tok(token.EOF, ""),
+		},
+		{
+			name:  "local with attrib",
+			input: `local x <const> = 1`,
+			want: ast.LocalStat{
+				NameAttribs: []ast.NameAttrib{nameAttrib("x", "const")},
+				Values:      []ast.ExpNode{ast.NewInt(1)},
 			},
 			want1: tok(token.EOF, ""),
 		},
@@ -1216,7 +1232,7 @@ func TestParser_Stat(t *testing.T) {
 		{
 			name:  "local single variable declaration with no value",
 			input: "local x z",
-			want:  ast.LocalStat{Names: []ast.Name{name("x")}},
+			want:  ast.LocalStat{NameAttribs: []ast.NameAttrib{nameAttrib("x")}},
 			want1: tok(token.IDENT, "z"),
 		},
 		{

--- a/runtime/comp.go
+++ b/runtime/comp.go
@@ -132,10 +132,6 @@ func le(t *Thread, x, y Value) (bool, *Error) {
 	if ok {
 		return Truth(res), err
 	}
-	res, err, ok = metabin(t, "__lt", y, x)
-	if ok {
-		return !Truth(res), err
-	}
 	return false, compareError(x, y)
 }
 

--- a/runtime/cont.go
+++ b/runtime/cont.go
@@ -17,6 +17,15 @@ type Cont interface {
 	Next() Cont
 	Parent() Cont
 	DebugInfo() *DebugInfo
+
+	// This will be called on pending continuations when the previous
+	// continuation returned with an error.  If there is nothing to do it should
+	// return the error unchanged, otherwise if it encounters another error
+	// during execution it may return the new error.
+	//
+	// This was intruduced to implement to-be-closed variables, a feature of Lua
+	// 5.4.
+	Cleanup(*Thread, *Error) *Error
 }
 
 // Push is a convenience method that pushes a number of values to the

--- a/runtime/error.go
+++ b/runtime/error.go
@@ -84,6 +84,9 @@ func (e *Error) AddContext(c Cont, depth int) {
 
 // Value returns the message of the error (which can be any Lua Value).
 func (e *Error) Value() Value {
+	if e == nil {
+		return NilValue
+	}
 	return e.message
 }
 

--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -129,6 +129,10 @@ func (c *GoCont) DebugInfo() *DebugInfo {
 	}
 }
 
+func (c *GoCont) Cleanup(t *Thread, err *Error) *Error {
+	return err
+}
+
 // NArgs returns the number of args pushed to the continuation.
 func (c *GoCont) NArgs() int {
 	return c.nArgs

--- a/runtime/lua/comp.lua
+++ b/runtime/lua/comp.lua
@@ -14,6 +14,16 @@ print(pcall(function() return {} < {} end))
 --> ~^false\t
 
 local t = {}
-setmetatable(t, {__lt=function(x, y) return not not y end})
-print(t < true, t <= false)
---> =true	false
+local meta = {__lt=function(x, y) return not not y end}
+setmetatable(t, meta)
+print(t < true)
+--> =true
+
+-- Since Lua 5.4 the __le metamethod is no longer inferred from __lt if __le is
+-- not implemented
+print(pcall(function() return t <= false end))
+--> ~false\t.*attempt to compare a table value with a boolean value
+
+meta.__le = meta.__lt
+print(t <= false)
+--> =false

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -1,3 +1,6 @@
+--
+-- const tests
+--
 
 local function test(src)
     local res, err = load(src)
@@ -38,3 +41,124 @@ test[[
     return foo + bar
 ]]
 --> ~false\t.*attempt to reassign constant variable 'bar'
+
+--
+-- to-be-closed tests
+--
+
+test[[
+    local x <close> = nil
+    x = 3
+]]
+--> ~false\t.*attempt to reassign constant variable 'x'
+
+test[[
+    local x <close> = 1
+]]
+--> ~false\t.*to be closed variable missing a __close metamethod
+
+function make(msg, err)
+    t = {}
+    setmetatable(t, {__close = function (x, e) 
+        if e ~= nil then
+            print(msg, e)
+        else
+            print(msg)
+        end
+        if err ~= nil then 
+            error(err)
+        end
+    end})
+    return t
+end
+
+do
+    local x <close> = make("x")
+    print("a")
+end
+print("b")
+--> =a
+--> =x
+--> =b
+
+do
+    local x <close> = make("x")
+    local y <close> = make("y")
+end
+--> =y
+--> =x
+
+do
+    local x <close>, y <close> = make("aa"), make("bb")
+end
+--> =bb
+--> =aa
+
+-- errors in close metamethods.  If a one produces an error, it looks like the
+-- next one is fed that error.
+pcall(function()
+    local x <close> = make("x")
+    local y <close> = make("y", "YY")
+    local z <close> = make("z")
+    local t <close> = make("t", "TT")
+    error("ERROR")
+end)
+--> ~t\t.*ERROR
+--> ~z\t.*TT
+--> ~y\t.*TT
+--> ~x\t.*YY
+
+-- A function to test to-be-closed variables
+local s
+function mk(a)
+    t = {}
+    s = s .. '+' .. a
+    setmetatable(t, {__close = function () s = s .. '-' .. a end})
+    return t
+end
+
+-- How it works
+do
+    s = "start"
+    local v <close> = mk("bob")
+    print(s)
+    --> =start+bob
+end
+print(s)
+--> =start+bob-bob
+
+do
+    s = "start"
+    local function f()
+        local a <close> = mk("a")
+        for i = 1, 3 do
+            local b <close> = mk("b"..i)
+        end
+        do
+            local c <close> = mk("c")
+            do
+                local d <close> = mk("d")
+                return
+            end
+        end
+    end
+    f()
+    print(s)
+    --> =start+a+b1-b1+b2-b2+b3-b3+c+d-d-c-a
+end
+
+do
+    s = "start"
+    local function f(n)
+        local x <close> = mk("x"..n)
+        if n > 0 then
+            f(n - 1)
+        else
+            error("stop")
+        end
+    end
+    print(pcall(f, 3))
+    --> ~false\t.*: stop
+    print(s)
+    --> =start+x3+x2+x1+x0-x0-x1-x2-x3
+end

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -1,0 +1,40 @@
+
+local function test(src)
+    local res, err = load(src)
+    if res ~= nil then
+        print(pcall(res))
+    else
+        print(false, err)
+    end
+end
+
+test[[
+    local foo <const> = 25
+    return foo
+]]
+--> =true	25
+
+test[[
+    local foo <const> = "hello"
+    foo = "bye"
+]]
+--> ~false\t.*attempt to reassign constant variable 'foo'
+
+test[[
+    local foo <const> = 25
+    local foo = foo + 2
+    return foo
+]]
+--> =true	27
+
+test[[
+    local foo, bar <const> = 25, 32
+    do
+        local bar
+        bar = 72
+    end
+    foo = foo + 2
+    bar = bar - 1
+    return foo + bar
+]]
+--> ~false\t.*attempt to reassign constant variable 'bar'

--- a/runtime/lua/thread.lua
+++ b/runtime/lua/thread.lua
@@ -28,3 +28,89 @@ do
     print(pcall(coroutine.yield, 1))
     --> ~cannot yield from main thread
 end
+
+--
+-- Coroutines and to-be-closed variables
+--
+
+function make(msg, err)
+    t = {}
+    setmetatable(t, {__close = function (x, e) 
+        if e ~= nil then
+            print(msg, e)
+        else
+            print(msg)
+        end
+        if err ~= nil then 
+            error(err)
+        end
+    end})
+    return t
+end
+
+do
+    local co = coroutine.create(function ()
+        local foo <close> = make("foo")
+        coroutine.yield()
+    end)
+    coroutine.resume(co)
+    print(coroutine.status(co))
+    --> =suspended
+    print(coroutine.close(co))
+    -- Output from closing the "foo" var
+    --> =foo
+    -- Outcome of coroutine.close(co)
+    --> =true
+    print(coroutine.status(co))
+    --> =dead
+end
+
+do
+    local function f(n)
+        local x <close> = make("x"..n)
+        if n > 1 then
+            f(n - 1)
+        else
+            coroutine.yield()
+        end
+    end
+    local co = coroutine.create(f)
+    coroutine.resume(co, 3)
+    print(coroutine.status(co))
+    --> =suspended
+    print(coroutine.close(co))
+    -- Output from closing the "x" vars
+    --> =x1
+    --> =x2
+    --> =x3
+    -- Outcome of coroutine.close(co)
+    --> =true
+    print(coroutine.status(co))
+    --> =dead
+end
+
+-- Wrapping this in pcall to suppress the default message handler which is
+-- adding traceback to error messages...
+pcall(function()
+    local function f(n)
+        local x <close> = make("x"..n, "ERR"..n)
+        if n > 1 then
+            f(n - 1)
+        else
+            coroutine.yield()
+        end
+    end
+    local co = coroutine.create(f)
+    coroutine.resume(co, 3)
+    print(coroutine.status(co))
+    --> =suspended
+    print(coroutine.close(co))
+    -- Output from closing the "x" vars
+    --> =x1
+    --> ~x2\t.*ERR1
+    --> ~x3\t.*ERR2
+    -- Outcome of coroutine.close(co)
+    --> ~false\t.*ERR3
+    print(coroutine.status(co))
+    --> =dead
+end)

--- a/runtime/termination.go
+++ b/runtime/termination.go
@@ -92,6 +92,10 @@ func (c *Termination) DebugInfo() *DebugInfo {
 	return c.parent.DebugInfo()
 }
 
+func (c *Termination) Cleanup(t *Thread, err *Error) *Error {
+	return err
+}
+
 // Get returns the n-th arg pushed to the termination.
 func (c *Termination) Get(n int) Value {
 	if n >= c.pushIndex {

--- a/runtime/thread_test.go
+++ b/runtime/thread_test.go
@@ -91,9 +91,9 @@ func TestThread_Yield(t *testing.T) {
 
 func TestThread_end(t *testing.T) {
 	type args struct {
-		args     []Value
-		err      *Error
-		quotaErr *ContextTerminationError
+		args  []Value
+		err   *Error
+		extra interface{}
 	}
 	quotaErr := ContextTerminationError{message: "boo!"}
 	tests := []struct {
@@ -132,7 +132,7 @@ func TestThread_end(t *testing.T) {
 				resumeCh: make(chan valuesError),
 			},
 			args: args{
-				quotaErr: &quotaErr,
+				extra: quotaErr,
 			},
 			wantPanic: quotaErr,
 		},
@@ -144,12 +144,12 @@ func TestThread_end(t *testing.T) {
 			gotPanic := func() (res interface{}) {
 				defer func() { res = recover() }()
 				caller := th.caller // The caller is removed when th is killed
-				th.end(tt.args.args, tt.args.err, tt.args.quotaErr)
+				th.end(tt.args.args, tt.args.err, tt.args.extra)
 				_, _ = caller.getResumeValues()
 				return
 			}()
 			if gotPanic != tt.wantPanic {
-				t.Errorf("Thread.end() panic got %v, want %v", gotPanic, tt.wantPanic)
+				t.Errorf("Thread.end() panic got %#v, want %#v", gotPanic, tt.wantPanic)
 			}
 		})
 	}


### PR DESCRIPTION
Quoting from the Lua 5.4 docs:

> The use of the __lt metamethod to emulate __le has been removed. When needed, this metamethod must be explicitly defined.

This PR makes the change above and adds some Lua tests for the new behaviour.