### PR TITLE
Lua 5.4 no string coercion in bitwise operations

### DIFF
--- a/runtime/bitwise.go
+++ b/runtime/bitwise.go
@@ -1,8 +1,8 @@
 package runtime
 
 func band(t *Thread, x, y Value) (Value, *Error) {
-	ix, okx := ToInt(x)
-	iy, oky := ToInt(y)
+	ix, okx := ToIntNoString(x)
+	iy, oky := ToIntNoString(y)
 	if okx && oky {
 		return IntValue(ix & iy), nil
 	}
@@ -14,8 +14,8 @@ func band(t *Thread, x, y Value) (Value, *Error) {
 }
 
 func bor(t *Thread, x, y Value) (Value, *Error) {
-	ix, okx := ToInt(x)
-	iy, oky := ToInt(y)
+	ix, okx := ToIntNoString(x)
+	iy, oky := ToIntNoString(y)
 	if okx && oky {
 		return IntValue(ix | iy), nil
 	}
@@ -27,8 +27,8 @@ func bor(t *Thread, x, y Value) (Value, *Error) {
 }
 
 func bxor(t *Thread, x, y Value) (Value, *Error) {
-	ix, okx := ToInt(x)
-	iy, oky := ToInt(y)
+	ix, okx := ToIntNoString(x)
+	iy, oky := ToIntNoString(y)
 	if okx && oky {
 		return IntValue(ix ^ iy), nil
 	}
@@ -40,8 +40,8 @@ func bxor(t *Thread, x, y Value) (Value, *Error) {
 }
 
 func shl(t *Thread, x, y Value) (Value, *Error) {
-	ix, okx := ToInt(x)
-	iy, oky := ToInt(y)
+	ix, okx := ToIntNoString(x)
+	iy, oky := ToIntNoString(y)
 
 	// We turn the value into an uint64 before shifting so that it's a logical
 	// shift, not arithmetic.
@@ -59,8 +59,8 @@ func shl(t *Thread, x, y Value) (Value, *Error) {
 }
 
 func shr(t *Thread, x, y Value) (Value, *Error) {
-	ix, okx := ToInt(x)
-	iy, oky := ToInt(y)
+	ix, okx := ToIntNoString(x)
+	iy, oky := ToIntNoString(y)
 
 	// We turn the value into an uint64 before shifting so that it's a logical
 	// shift, not arithmetic.
@@ -78,7 +78,7 @@ func shr(t *Thread, x, y Value) (Value, *Error) {
 }
 
 func bnot(t *Thread, x Value) (Value, *Error) {
-	ix, okx := ToInt(x)
+	ix, okx := ToIntNoString(x)
 	if okx {
 		return IntValue(^ix), nil
 	}

--- a/runtime/lua/bitwise.lua
+++ b/runtime/lua/bitwise.lua
@@ -6,3 +6,32 @@ print(1 >> -3)
 
 print(10 << -2)
 --> =2
+
+local function perr(s)
+    local ok, err = pcall(load("return " .. s))
+    print(err)
+end
+
+perr[[100 & "2"]]
+--> ~.*attempt to perform bitwise and on a string value
+
+perr[["100" | 23]]
+--> ~.*attempt to perform bitwise or on a string value
+
+perr[[~"55"]]
+--> ~.*attempt to perform bitwise not on a string value
+
+perr[[23 ~ "5"]]
+--> ~.*attempt to perform bitwise xor on a string value
+
+perr[["77" >> 9]]
+--> ~.*attempt to perform bitwise shr on a string value
+
+perr[["123" << "456" ]]
+--> ~.*attempt to perform bitwise shl on a string value
+
+perr[[0.5 | 1.2]]
+--> ~.*number has no integer representation
+
+perr[[45.2 >> "a"]]
+--> ~.*attempt to perform bitwise shr on a string value


### PR DESCRIPTION
From the Lua 5.4 docs

> The coercion of strings to numbers in arithmetic and bitwise operations has been removed from the core language.

This is implemented in this PR, with some Lua tests

Note that it breaks the Lua 5.3 Test Suite, so CI is broken until I switch to the Lua 5.4 Test Suite