### PR TITLE
Lua 5.4: Error when declaring a label with an existing name

### DIFF
--- a/astcomp/compexp.go
+++ b/astcomp/compexp.go
@@ -91,7 +91,7 @@ func (c *expCompiler) compileLogicalOp(b ast.BinOp, not bool) {
 			c.emitInstr(r.Operand, ir.JumpIf{Cond: c.dst, Label: doneLbl, Not: not})
 		}
 	}
-	must(c.EmitLabel(doneLbl))
+	must(c.EmitLabelNoLine(doneLbl))
 }
 
 // ProcesBoolExp compiles a oolExp.

--- a/astcomp/compstat.go
+++ b/astcomp/compstat.go
@@ -84,7 +84,7 @@ func (c *compiler) ProcessForInStat(s ast.ForInStat) {
 		Lsrc: var1,
 		Rsrc: testReg,
 	})
-	endLbl := c.DeclareGotoLabel(breakLblName, -1)
+	endLbl := c.DeclareGotoLabelNoLine(breakLblName)
 	c.emitInstr(s, ir.JumpIf{Cond: testReg, Label: endLbl})
 	c.emitInstr(s, ir.Transform{Dst: varReg, Op: ops.OpId, Src: var1})
 	c.compileBlock(s.Body)
@@ -127,7 +127,7 @@ func (c *compiler) ProcessForStat(s ast.ForStat) {
 	c.PushContext()
 	loopLbl := c.GetNewLabel()
 	must(c.EmitLabelNoLine(loopLbl))
-	endLbl := c.DeclareGotoLabel(breakLblName, 0)
+	endLbl := c.DeclareGotoLabelNoLine(breakLblName)
 
 	// If startReg is nil, then there are no iterations in the loop
 	c.EmitNoLine(ir.JumpIf{
@@ -246,7 +246,7 @@ func (c *compiler) ProcessLocalStat(s ast.LocalStat) {
 // ProcessRepeatStat compiles a RepeatStat.
 func (c *compiler) ProcessRepeatStat(s ast.RepeatStat) {
 	c.PushContext()
-	c.DeclareGotoLabel(breakLblName, -1)
+	c.DeclareGotoLabelNoLine(breakLblName)
 
 	loopLbl := c.GetNewLabel()
 	must(c.EmitLabelNoLine(loopLbl))
@@ -271,7 +271,7 @@ func (c *compiler) ProcessRepeatStat(s ast.RepeatStat) {
 // ProcessWhileStat compiles a WhileStat.
 func (c *compiler) ProcessWhileStat(s ast.WhileStat) {
 	c.PushContext()
-	stopLbl := c.DeclareGotoLabel(breakLblName, -1)
+	stopLbl := c.DeclareGotoLabelNoLine(breakLblName)
 
 	loopLbl := c.GetNewLabel()
 	must(c.EmitLabelNoLine(loopLbl))

--- a/astcomp/compstat.go
+++ b/astcomp/compstat.go
@@ -375,7 +375,13 @@ func getLabels(c *ir.CodeBuilder, statements []ast.Stat) {
 	for _, stat := range statements {
 		switch s := stat.(type) {
 		case ast.LabelStat:
-			c.DeclareGotoLabel(ir.Name(s.Name.Val))
+			_, err := c.DeclareUniqueGotoLabel(ir.Name(s.Name.Val))
+			if err != nil {
+				panic(Error{
+					Where:   s.Name,
+					Message: err.Error(),
+				})
+			}
 		case ast.LocalStat, ast.LocalFunctionStat:
 			return
 		}
@@ -389,7 +395,13 @@ func getBackLabels(c *ir.CodeBuilder, statements []ast.Stat) int {
 		case ast.EmptyStat:
 			// That doesn't count
 		case ast.LabelStat:
-			c.DeclareGotoLabel(ir.Name(s.Name.Val))
+			_, err := c.DeclareUniqueGotoLabel(ir.Name(s.Name.Val))
+			if err != nil {
+				panic(Error{
+					Where:   s.Name,
+					Message: err.Error(),
+				})
+			}
 		default:
 			return count
 		}

--- a/astcomp/emitters.go
+++ b/astcomp/emitters.go
@@ -18,7 +18,7 @@ func (c *compiler) emitJump(l ast.Locator, lbl ir.Name) {
 	if !c.CodeBuilder.EmitJump(lbl, getLine(l)) {
 		panic(Error{
 			Where:   l,
-			Message: fmt.Sprintf("undefined label '%s'", lbl),
+			Message: fmt.Sprintf("no visible label '%s'", lbl),
 		})
 	}
 }

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -60,6 +60,14 @@ func (c *CodeBuilder) Dump() {
 	}
 }
 
+func (c *CodeBuilder) DeclareUniqueGotoLabel(name Name) (Label, error) {
+	_, ok := c.getGotoLabel(name)
+	if ok {
+		return 0, fmt.Errorf("label '%s' already defined", name)
+	}
+	return c.DeclareGotoLabel(name), nil
+}
+
 func (c *CodeBuilder) DeclareGotoLabel(name Name) Label {
 	lbl := c.GetNewLabel()
 	c.context.addLabel(name, lbl)

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -60,33 +60,36 @@ func (c *CodeBuilder) Dump() {
 	}
 }
 
-func (c *CodeBuilder) DeclareUniqueGotoLabel(name Name) (Label, error) {
-	_, ok := c.getGotoLabel(name)
+func (c *CodeBuilder) DeclareUniqueGotoLabel(name Name, line int) (Label, error) {
+	_, prevLine, ok := c.getGotoLabel(name)
 	if ok {
+		if prevLine > 0 {
+			return 0, fmt.Errorf("label '%s' already defined at line %d", name, prevLine)
+		}
 		return 0, fmt.Errorf("label '%s' already defined", name)
 	}
-	return c.DeclareGotoLabel(name), nil
+	return c.DeclareGotoLabel(name, line), nil
 }
 
-func (c *CodeBuilder) DeclareGotoLabel(name Name) Label {
+func (c *CodeBuilder) DeclareGotoLabel(name Name, line int) Label {
 	lbl := c.GetNewLabel()
-	c.context.addLabel(name, lbl)
+	c.context.addLabel(name, lbl, line)
 	return lbl
 }
 
-func (c *CodeBuilder) getGotoLabel(name Name) (Label, bool) {
+func (c *CodeBuilder) getGotoLabel(name Name) (Label, int, bool) {
 	return c.context.getLabel(name)
 }
 
 func (c *CodeBuilder) EmitGotoLabel(name Name) error {
-	label, ok := c.getGotoLabel(name)
+	label, line, ok := c.getGotoLabel(name)
 	if !ok {
 		return fmt.Errorf("cannot emit undeclared label '%s'", name)
 	}
 	if c.labels[label] {
 		return fmt.Errorf("label '%s' used twice", name)
 	}
-	return c.EmitLabel(label)
+	return c.EmitLabel(label, line)
 }
 
 func (c *CodeBuilder) GetNewLabel() Label {
@@ -95,13 +98,17 @@ func (c *CodeBuilder) GetNewLabel() Label {
 	return lbl
 }
 
-func (c *CodeBuilder) EmitLabel(lbl Label) error {
+func (c *CodeBuilder) EmitLabel(lbl Label, line int) error {
 	if c.labels[lbl] {
 		return fmt.Errorf("label '%s' emitted twice", lbl)
 	}
 	c.labels[lbl] = true
-	c.EmitNoLine(DeclareLabel{Label: lbl})
+	c.Emit(DeclareLabel{Label: lbl}, line)
 	return nil
+}
+
+func (c *CodeBuilder) EmitLabelNoLine(lbl Label) error {
+	return c.EmitLabel(lbl, 0)
 }
 
 func (c *CodeBuilder) GetRegister(name Name) (Register, bool) {
@@ -194,7 +201,7 @@ func (c *CodeBuilder) EmitJump(lblName Name, line int) bool {
 	)
 	for len(lc) > 0 {
 		lc, top = lc.pop()
-		if lbl, ok := top.label[lblName]; ok {
+		if lbl, line, ok := top.getLabel(lblName); ok {
 			c.emitTruncate(top)
 			c.Emit(Jump{Label: lbl}, line)
 			return true

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -71,6 +71,10 @@ func (c *CodeBuilder) DeclareUniqueGotoLabel(name Name, line int) (Label, error)
 	return c.DeclareGotoLabel(name, line), nil
 }
 
+func (c *CodeBuilder) DeclareGotoLabelNoLine(name Name) Label {
+	return c.DeclareGotoLabel(name, 0)
+}
+
 func (c *CodeBuilder) DeclareGotoLabel(name Name, line int) Label {
 	lbl := c.GetNewLabel()
 	c.context.addLabel(name, lbl, line)

--- a/runtime/lua/goto.lua
+++ b/runtime/lua/goto.lua
@@ -17,7 +17,7 @@ print(load([[
     ::cont::
   until xuxu < x
 ]]))
---> ~nil\t.*undefined label 'cont'
+--> ~nil\t.*no visible label 'cont'
 
 -- Lua 5.4 forbids shadowing labels
 
@@ -27,7 +27,7 @@ print(load[[
   ::label::
   print"bye"
 ]])
---> ~nil\t.*label 'label' already defined
+--> ~nil\t.*label 'label' already defined at line 1
 
 print(load[[
   ::foo::
@@ -36,7 +36,7 @@ print(load[[
     goto foo
   end
 ]])
---> ~nil\t.*label 'foo' already defined
+--> ~nil\t.*label 'foo' already defined at line 1
 
 -- It's OK to reuse a label name that was defined outside the current function
 -- scope.

--- a/runtime/lua/goto.lua
+++ b/runtime/lua/goto.lua
@@ -18,3 +18,39 @@ print(load([[
   until xuxu < x
 ]]))
 --> ~nil\t.*undefined label 'cont'
+
+-- Lua 5.4 forbids shadowing labels
+
+print(load[[
+  ::label::
+  print"hello"
+  ::label::
+  print"bye"
+]])
+--> ~nil\t.*label 'label' already defined
+
+print(load[[
+  ::foo::
+  do
+    ::foo::
+    goto foo
+  end
+]])
+--> ~nil\t.*label 'foo' already defined
+
+-- It's OK to reuse a label name that was defined outside the current function
+-- scope.
+do
+  ::l2::
+  local f = function(n)
+    ::l2::
+    print(n)
+    n = n - 1
+    if n > 0 then
+      goto l2
+    end
+  end
+  f(2)
+end
+--> =2
+--> =1


### PR DESCRIPTION
From the Lua 5.4 docs:

>A label for a goto cannot be declared where a label with the same name is visible, even if this other label is declared in an enclosing block.

This PR implements the above, adding some Lua tests to check.  It is not specified whether a visible label in a parent function should trigger the error, but I have checked the implementation and it allows it.

This changes is backward incompatible and breaks the Lua 5.3 Test Suite.  So CI is broken until I switch to the Lua 5.4 Test Suite.