### PR TITLE
Implement to-be-closed argument in generic for loop (Lua 5.4)

### DIFF
--- a/astcomp/compstat.go
+++ b/astcomp/compstat.go
@@ -43,13 +43,15 @@ func (c *compiler) ProcessEmptyStat(s ast.EmptyStat) {
 
 // ProcessForInStat compiles a ForInStat.
 func (c *compiler) ProcessForInStat(s ast.ForInStat) {
-	initRegs := make([]ir.Register, 3)
+	initRegs := make([]ir.Register, 4)
 	c.compileExpList(s.Params, initRegs)
 	fReg := initRegs[0]
 	sReg := initRegs[1]
 	varReg := initRegs[2]
+	closeReg := initRegs[3]
 
 	c.PushContext()
+	c.PushCloseAction(closeReg) // Now closeReg is no longer needed
 	c.DeclareLocal(loopFRegName, fReg)
 	c.DeclareLocal(loopSRegName, sReg)
 	c.DeclareLocal(loopVarRegName, varReg)

--- a/runtime/lua/forin.lua
+++ b/runtime/lua/forin.lua
@@ -1,0 +1,19 @@
+-- Lua 5.4 introduces a 4th return value in the for in statement, which works as
+-- a to be closed variable.
+
+local foo = {}
+setmetatable(foo, {__close=function() print"close foo" end})
+
+local r3 = function(s, i)
+    if i < 3 then return i + 1 else return nil end
+end
+
+for i in r3, nil, 0, foo do
+    print(i)
+end
+print"done"
+--> =1
+--> =2
+--> =3
+--> =close foo
+--> =done


### PR DESCRIPTION
From the Lua 5.4 docs:

>The loop starts by evaluating explist to produce four values: an iterator function, a state, an initial value for the control variable, and a closing value.
>...
>The closing value behaves like a to-be-closed variable (see §3.3.8), which can be used to release resources when the loop ends. Otherwise, it does not interfere with the loop.

This PR implements the above, with a Lua test to check the behaviour.
