### PR TITLE
Lua 5.4 numeric for loop

### DIFF
--- a/code/instructions.go
+++ b/code/instructions.go
@@ -218,3 +218,17 @@ func LoadEtcLookup(r1, r2 Reg, i int) Opcode {
 func FillTable(r1, r2 Reg, i int) Opcode {
 	return mkType6(On, r1, r2, Index8FromInt(i))
 }
+
+// PrepForLoop makes sure rStart, rStep, rStop are all numbers and converts
+// rStart and rStep to the same numeric type. If rStep is nil, then it is set to
+// 1. If the for loop should already stop then rStart is set to nil
+func PrepForLoop(rStart, rStop, rStep Reg) Opcode {
+	return mkType7(Off, rStart, rStop, rStep)
+}
+
+// AdvForLoop increments rStart by rStep, making sure that it doesn't wrap
+// around if it is an integer.  If it wraps around then the loop should stop. If
+// the loop should stop, rStart is set to nil
+func AdvForLoop(rStart, rStop, rStep Reg) Opcode {
+	return mkType7(On, rStart, rStop, rStep)
+}

--- a/code/instructions.go
+++ b/code/instructions.go
@@ -220,8 +220,8 @@ func FillTable(r1, r2 Reg, i int) Opcode {
 }
 
 // PrepForLoop makes sure rStart, rStep, rStop are all numbers and converts
-// rStart and rStep to the same numeric type. If rStep is nil, then it is set to
-// 1. If the for loop should already stop then rStart is set to nil
+// rStart and rStep to the same numeric type. If the for loop should already
+// stop then rStart is set to nil
 func PrepForLoop(rStart, rStop, rStep Reg) Opcode {
 	return mkType7(Off, rStart, rStop, rStep)
 }

--- a/code/opcodes.go
+++ b/code/opcodes.go
@@ -240,7 +240,6 @@ const (
 	OpNot                  // Added afterwards - why did I not have it in the first place?
 	OpUpvalue              // get an upvalue
 	OpEtcId                // etc identity
-	OpToNumber             // convert to number
 )
 
 // encodeZ enocodes an UnOp into an opcode.
@@ -581,8 +580,6 @@ func (c Opcode) Disassemble(d OpcodeDisassembler, i int) string {
 				tpl = "bool(%s)"
 			case OpNot:
 				tpl = "not %s"
-			case OpToNumber:
-				tpl = "tonumber(%s)"
 			case OpUpvalue:
 				// Special case
 				return fmt.Sprintf("upval %s, %s", rA, rB)

--- a/code/opcodes.go
+++ b/code/opcodes.go
@@ -21,6 +21,7 @@ const (
 	Type4Pfx Opcode = 5 << 28 // 0101...
 	Type5Pfx Opcode = 4 << 28 // 0100...
 	Type6Pfx Opcode = 3 << 28 // 0011...
+	Type7Pfx Opcode = 2 << 28 // 0010...
 	Type0Pfx Opcode = 0 << 28 // 0000...
 
 	type4aFlag Opcode = 1 << 24
@@ -423,6 +424,15 @@ func mkType6(f Flag, rA, rB Reg, i Index8) Opcode {
 }
 
 // ==================================================================
+// Type7:  0010Fabc AAAAAAAA BBBBBBBB CCCCCCCC
+//
+// For loop opcodes
+
+func mkType7(f Flag, rA, rB, rC Reg) Opcode {
+	return Type7Pfx | f.encodeF() | rA.toA() | rB.toB() | rC.toC()
+}
+
+// ==================================================================
 // Type0:  0000Fabc AAAAAAAA BBBBBBBB CCCCCCCC
 //
 // Receiving args
@@ -671,6 +681,13 @@ func (c Opcode) Disassemble(d OpcodeDisassembler, i int) string {
 			return fmt.Sprintf("fill %s, %d, %s", rA, m, rB)
 		}
 		return fmt.Sprintf("%s <- etclookup(%s, %d)", rA, rB, m)
+	case Type7Pfx:
+		rStart, rStop, rStep := c.GetA(), c.GetB(), c.GetC()
+		action := "prep"
+		if c.GetF() {
+			action = "adv"
+		}
+		return fmt.Sprintf("%sfor %s, %s, %s", action, rStart, rStop, rStep)
 	default:
 		return "???"
 	}

--- a/ir/instructions.go
+++ b/ir/instructions.go
@@ -43,6 +43,8 @@ type InstrProcessor interface {
 	ProcessFillTableInstr(FillTable)
 	ProcessTruncateCloseStackInstr(TruncateCloseStack)
 	ProcessPushCloseStackInstr(PushCloseStack)
+	ProcessPrepForLoopInstr(PrepForLoop)
+	ProcessAdvForLoopInstr(AdvForLoop)
 
 	// These are hints that a register is needed or no longer needed.
 	ProcessTakeRegisterInstr(TakeRegister)
@@ -498,4 +500,31 @@ func (l DeclareLabel) String() string {
 // ProcessInstr makes the InstrProcessor process this instruction.
 func (l DeclareLabel) ProcessInstr(p InstrProcessor) {
 	p.ProcessDeclareLabelInstr(l)
+}
+
+// PrepForLoop prepares a for loop
+type PrepForLoop struct {
+	Start, Stop, Step Register
+}
+
+func (i PrepForLoop) String() string {
+	return fmt.Sprintf("prepfor %s, %s, %s", i.Start, i.Stop, i.Step)
+}
+
+func (i PrepForLoop) ProcessInstr(p InstrProcessor) {
+	p.ProcessPrepForLoopInstr(i)
+}
+
+// AdvForLoop advances a for loop
+
+type AdvForLoop struct {
+	Start, Stop, Step Register
+}
+
+func (i AdvForLoop) String() string {
+	return fmt.Sprintf("advfor %s, %s, %s", i.Start, i.Stop, i.Step)
+}
+
+func (i AdvForLoop) ProcessInstr(p InstrProcessor) {
+	p.ProcessAdvForLoopInstr(i)
 }

--- a/ircomp/compinstr.go
+++ b/ircomp/compinstr.go
@@ -227,9 +227,18 @@ func (ic instrCompiler) ProcessPushCloseStackInstr(p ir.PushCloseStack) {
 	ic.Emit(code.ClPush(ic.codeReg(p.Src)))
 }
 
+// ProcessPrepForLoopInstr compiles a PrepForLoop instruction.
+func (ic instrCompiler) ProcessPrepForLoopInstr(i ir.PrepForLoop) {
+	ic.Emit(code.PrepForLoop(ic.codeReg(i.Start), ic.codeReg(i.Stop), ic.codeReg(i.Step)))
+}
+
+// ProcessAdvForLoopInstr compiles an AdvForLoop instruction.
+func (ic instrCompiler) ProcessAdvForLoopInstr(i ir.AdvForLoop) {
+	ic.Emit(code.AdvForLoop(ic.codeReg(i.Start), ic.codeReg(i.Stop), ic.codeReg(i.Step)))
+}
+
 func (ic instrCompiler) ProcessTakeRegisterInstr(t ir.TakeRegister) {
 	ic.takeRegister(t.Reg)
-
 }
 
 func (ic instrCompiler) ProcessReleaseRegisterInstr(r ir.ReleaseRegister) {

--- a/ircomp/compinstr.go
+++ b/ircomp/compinstr.go
@@ -66,12 +66,11 @@ func (ic instrCompiler) ProcessTransformInstr(t ir.Transform) {
 }
 
 var codeUnOp = map[ops.Op]code.UnOp{
-	ops.OpNeg:      code.OpNeg,
-	ops.OpNot:      code.OpNot,
-	ops.OpLen:      code.OpLen,
-	ops.OpBitNot:   code.OpBitNot,
-	ops.OpId:       code.OpId,
-	ops.OpToNumber: code.OpToNumber,
+	ops.OpNeg:    code.OpNeg,
+	ops.OpNot:    code.OpNot,
+	ops.OpLen:    code.OpLen,
+	ops.OpBitNot: code.OpBitNot,
+	ops.OpId:     code.OpId,
 }
 
 // ProcessLoadConstInstr compiles a LoadConst instruction.

--- a/notes/numeric-for.md
+++ b/notes/numeric-for.md
@@ -1,0 +1,55 @@
+In Lua 5.4 the docs specify numeric for loops as working as follows
+
+>The loop starts by evaluating once the three control expressions. Their values
+>are called respectively the initial value, the limit, and the step. If the step
+>is absent, it defaults to 1.
+
+>If both the initial value and the step are integers, the loop is done with
+>integers; note that the limit may not be an integer. Otherwise, the three
+>values are converted to floats and the loop is done with floats. Beware of
+>floating-point accuracy in this case.
+
+>After that initialization, the loop body is repeated with the value of the
+>control variable going through an arithmetic progression, starting at the
+>initial value, with a common difference given by the step. A negative step
+>makes a decreasing sequence; a step equal to zero raises an error. The loop
+>continues while the value is less than or equal to the limit (greater than or
+>equal to for a negative step). If the initial value is already greater than the
+>limit (or less than, if the step is negative), the body is not executed.
+
+>For integer loops, the control variable never wraps around; instead, the loop
+>ends in case of an overflow.
+
+This means that if a loop variable is an integer and this integer overflows /
+underflows when it is incremented / decremented then the loops stops
+immediately.  E.g. the following loop will stop after one iteration instead of i
+wrapping around and the loop carrying on forever.
+
+```lua
+for i = math.maxinteger, 1e100 do end
+```
+
+It isn't practical to try to implement the semantics of the for loop as
+described above in terms of existing opcodes.
+
+Instead two new opcodes are introduced:
+- `prepfor rStart, rStop, rStep`: makes sure `rStart`, `rStep`, `rStop` are all
+  numbers and converts `rStart` and `rStep` to the same numeric type. If the for
+  loop should already stop then `rStart` is set to nil.
+- `advfor rStart, rStop, rStep`: increments `rStart` by `rStep`, making sure
+  that it doesn't wrap around if it is an integer.  If it wraps around then the
+  loop should stop. If the loop should stop, `rStart` is set to nil.
+
+With these two new opcodes it becomes easy to compile a numeric for loop.
+Assuming `r1`, `r2`,  `r3` contain the start, stop and step initial values:
+
+```
+     prepfor r1, r2, r3
+     if not r1 jump END
+LOOP:
+     r4 <- r1
+     [compiled body of loop where the loop variable is r4]
+     advfor r1, r2, r3
+     if r1 jump LOOP
+END:
+```

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -65,9 +65,6 @@ const (
 // OpPow (power) is special, precendence 10.
 const OpPow Op = 11 + iota<<8
 
-// OpToNumber is used in e.g. for loops
-const OpToNumber Op = 0x10000
-
 // Precedence returns the precedence of an operator (higher means binds more
 // tightly).
 func (op Op) Precedence() int {

--- a/runtime/comp.go
+++ b/runtime/comp.go
@@ -19,8 +19,8 @@ func RawEqual(x, y Value) (bool, bool) {
 	return false, false
 }
 
-// IsZero returns true if x is a number and is equal to 0
-func IsZero(x Value) bool {
+// isZero returns true if x is a number and is equal to 0
+func isZero(x Value) bool {
 	switch x.iface.(type) {
 	case int64:
 		return x.AsInt() == 0
@@ -30,8 +30,8 @@ func IsZero(x Value) bool {
 	return false
 }
 
-// IsPositive returns true if x is a number and is > 0
-func IsPositive(x Value) bool {
+// isPositive returns true if x is a number and is > 0
+func isPositive(x Value) bool {
 	switch x.iface.(type) {
 	case int64:
 		return x.AsInt() > 0
@@ -61,7 +61,7 @@ func numIsLessThan(x, y Value) bool {
 	return false
 }
 
-func IsLessThan(x, y Value) (bool, bool) {
+func isLessThan(x, y Value) (bool, bool) {
 	switch x.iface.(type) {
 	case int64:
 		switch y.iface.(type) {
@@ -108,7 +108,7 @@ func eq(t *Thread, x, y Value) (bool, *Error) {
 // Lt returns whether x < y is true (and an error if it's not possible to
 // compare them).
 func Lt(t *Thread, x, y Value) (bool, *Error) {
-	lt, ok := IsLessThan(x, y)
+	lt, ok := isLessThan(x, y)
 	if ok {
 		return lt, nil
 	}

--- a/runtime/lua/for.lua
+++ b/runtime/lua/for.lua
@@ -1,0 +1,39 @@
+local function countsteps(start, stop, step)
+    local n = 0
+    if step then
+        for i = start, stop, step do
+            n = n + 1
+        end
+    else
+        for i = start, stop do
+            n = n + 1
+        end
+    end
+    return n
+end
+
+print(countsteps(1, 3))
+--> =3
+
+print(countsteps(math.maxinteger - 1, 1e100))
+--> =2
+
+print(countsteps(1, -10))
+--> =0
+
+print(countsteps(math.mininteger, math.mininteger + 1))
+--> =2
+
+print(countsteps(math.mininteger + 2, -1e100, -1))
+--> =3
+
+print(countsteps(1.0, 6, 2))
+--> =3
+
+for i = 1, 2, 1.1 do
+    print(math.type(i))
+end
+--> =float
+
+print(pcall(function() for i = 1, 1, 0 do end end))
+--> ~false\t.*'for' step is zero

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -436,7 +436,7 @@ RunLoop:
 				// over the stop value or if there has been overflow /
 				// underflow.
 				var done bool
-				if IsPositive(step) {
+				if isPositive(step) {
 					done = numIsLessThan(stop, nextStart) || numIsLessThan(nextStart, start)
 				} else {
 					done = numIsLessThan(nextStart, stop) || numIsLessThan(start, nextStart)
@@ -464,17 +464,17 @@ RunLoop:
 					}
 				}
 				// A 0 step is an error
-				if IsZero(step) {
+				if isZero(step) {
 					c.pc = pc
 					return nil, NewErrorS("'for' step is zero")
 				}
 				// Check the loop is not already finished. If so, startReg is
 				// set to nil.
 				var done bool
-				if IsPositive(step) {
-					done, _ = IsLessThan(stop, start)
+				if isPositive(step) {
+					done, _ = isLessThan(stop, start)
 				} else {
-					done, _ = IsLessThan(start, stop)
+					done, _ = isLessThan(start, stop)
 				}
 				if done {
 					start = NilValue

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -297,12 +297,6 @@ RunLoop:
 					continue RunLoop
 				case code.OpTruth:
 					res = BoolValue(Truth(val))
-				case code.OpToNumber:
-					var tp NumberType
-					res, tp = ToNumberValue(val)
-					if tp == NaN {
-						err = NewErrorS("expected numeric value")
-					}
 				case code.OpNot:
 					res = BoolValue(!Truth(val))
 				case code.OpUpvalue:

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -428,6 +428,69 @@ RunLoop:
 			}
 			pc++
 			continue RunLoop
+		case code.Type7Pfx:
+			startReg, stopReg, stepReg := opcode.GetA(), opcode.GetB(), opcode.GetC()
+			start := getReg(regs, cells, startReg)
+			stop := getReg(regs, cells, stopReg)
+			step := getReg(regs, cells, stepReg)
+			if opcode.GetF() {
+				// Advance for loop.  All registers are assumed to contain
+				// numeric values because they have been prepared previously.
+				nextStart, _ := Add(start, step)
+
+				// Check if the loop is done.  It can be done if we have gone
+				// over the stop value or if there has been overflow /
+				// underflow.
+				var done bool
+				if IsPositive(step) {
+					done = numIsLessThan(stop, nextStart) || numIsLessThan(nextStart, start)
+				} else {
+					done = numIsLessThan(nextStart, stop) || numIsLessThan(start, nextStart)
+				}
+				if done {
+					nextStart = NilValue
+				}
+				setReg(regs, cells, startReg, nextStart)
+			} else {
+				// Prepare for loop
+				start, tstart := ToNumberValue(start)
+				stop, tstop := ToNumberValue(stop)
+				step, tstep := ToNumberValue(step)
+				if tstart == NaN || tstop == NaN || tstep == NaN {
+					c.pc = pc
+					return nil, NewErrorS("expected numeric value")
+				}
+				// Make sure start and step have the same numeric type
+				if tstart != tstep {
+					// One is a float, one is an int, turn them both to floats
+					if tstart == IsInt {
+						start = FloatValue(float64(start.AsInt()))
+					} else {
+						step = FloatValue(float64(step.AsInt()))
+					}
+				}
+				// A 0 step is an error
+				if IsZero(step) {
+					c.pc = pc
+					return nil, NewErrorS("'for' step is zero")
+				}
+				// Check the loop is not already finished. If so, startReg is
+				// set to nil.
+				var done bool
+				if IsPositive(step) {
+					done, _ = IsLessThan(stop, start)
+				} else {
+					done, _ = IsLessThan(start, stop)
+				}
+				if done {
+					start = NilValue
+				}
+				setReg(regs, cells, startReg, start)
+				setReg(regs, cells, stopReg, stop)
+				setReg(regs, cells, stepReg, step)
+			}
+			pc++
+			continue RunLoop
 		}
 	}
 	// return nil, errors.New("Invalid PC")


### PR DESCRIPTION
In Lua 5.4 there is a slight change in the semantics of the numeric for loop, the Lua docs say:

>For integer loops, the control variable never wraps around; instead, the loop ends in case of an overflow.

This means that if a loop variable is an integer and this integer overflows / underflows when it is incremented / decremented then the loops stops immediately.  E.g. the following loop will stop after one iteration instead of i wrapping around and the loop carrying on forever.

```lua
for i = math.maxinteger, 1e100 do end
```

This PR implements the above.  This is not trivial because previously numeric for loop were compiled into quite a complex sequence of opcodes and it wasn't practical to try to implement the new semantics of the for loop in terms of existing opcodes.

Instead two new opcodes are introduced:
- `prepfor rStart, rStop, rStep`: makes sure `rStart`, `rStep`, `rStop` are all numbers and converts `rStart` and `rStep` to the same numeric type. If the for loop should already stop then `rStart` is set to nil.
- `advfor rStart, rStop, rStep`: increments `rStart` by `rStep`, making sure that it doesn't wrap around if it is an integer.  If it wraps around then the loop should stop. If the loop should stop, `rStart` is set to nil.

With these two new opcodes it becomes easy to compile a numeric for loop.  Assuming `r1`, `r2`,  `r3` contain the start, stop and step initial values:

```
     prepfor r1, r2, r3
     if not r1 jump END
LOOP:
     r4 <- r1
     [compiled body of loop where the loop variable is r4]
     advfor r1, r2, r3
     if r1 jump LOOP
END:
```
