### PR TITLE
Lua 5.4 math randomseed

### DIFF
--- a/lib/mathlib/lua/mathlib.lua
+++ b/lib/mathlib/lua/mathlib.lua
@@ -141,6 +141,13 @@ do
     print(r1 == r2)
     --> =false
 
+    local s1, s2 = math.randomseed()
+    r1 = math.random()
+    math.randomseed(s1, s2)
+    r2 = math.random()
+    print(r1 == r2)
+    --> =true
+
     print(not pcall(math.randomseed, "hi"))
     --> =true
 

--- a/lib/mathlib/lua/mathlib.lua
+++ b/lib/mathlib/lua/mathlib.lua
@@ -134,8 +134,24 @@ do
 end
 
 do
-    checknumarg(math.randomseed)
-    --> =ok
+    math.randomseed()
+    local r1 = math.random()
+    math.randomseed()
+    local r2 = math.random()
+    print(r1 == r2)
+    --> =false
+
+    print(not pcall(math.randomseed, "hi"))
+    --> =true
+
+    print(not pcall(math.randomseed, 1, {}))
+    --> =true
+
+    print(not pcall(math.randomseed, 1.1, 2))
+    --> =true
+
+    print(not pcall(rand))
+    --> =true
 
     local r = math.random()
     print(r >= 0 and r <= 1)

--- a/lib/mathlib/mathlib.go
+++ b/lib/mathlib/mathlib.go
@@ -365,7 +365,7 @@ func randomseed(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 		seed ^= seed2
 	}
 	rand.Seed(seed)
-	return c.Next(), nil
+	return c.PushingNext(t.Runtime, rt.IntValue(seed), rt.IntValue(0)), nil
 }
 
 func sin(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {

--- a/lib/mathlib/mathlib.go
+++ b/lib/mathlib/mathlib.go
@@ -3,6 +3,7 @@ package mathlib
 import (
 	"math"
 	"math/rand"
+	"time"
 
 	"github.com/arnodel/golua/lib/packagelib"
 	rt "github.com/arnodel/golua/runtime"
@@ -39,7 +40,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 		r.SetEnvGoFunc(pkg, "modf", modf, 1, false),
 		r.SetEnvGoFunc(pkg, "rad", rad, 1, false),
 		r.SetEnvGoFunc(pkg, "random", random, 2, false),
-		r.SetEnvGoFunc(pkg, "randomseed", randomseed, 1, false),
+		r.SetEnvGoFunc(pkg, "randomseed", randomseed, 2, false),
 		r.SetEnvGoFunc(pkg, "sin", sin, 1, false),
 		r.SetEnvGoFunc(pkg, "sqrt", sqrt, 1, false),
 		r.SetEnvGoFunc(pkg, "tan", tan, 1, false),
@@ -340,14 +341,30 @@ func random(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 }
 
 func randomseed(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
-	if err := c.Check1Arg(); err != nil {
-		return nil, err
+	var seed int64
+	var err *rt.Error
+	switch c.NArgs() {
+	case 0:
+		// Something "random"
+		seed = time.Now().UnixNano()
+	case 1:
+		seed, err = c.IntArg(0)
+		if err != nil {
+			return nil, err
+		}
+	case 2:
+		seed, err = c.IntArg(0)
+		if err != nil {
+			return nil, err
+		}
+		seed2, err := c.IntArg(1)
+		if err != nil {
+			return nil, err
+		}
+		// In Go the seed is only 64 bits so we mangle the seeds
+		seed ^= seed2
 	}
-	seed, err := c.IntArg(0)
-	if err != nil {
-		return nil, err
-	}
-	rand.Seed(int64(seed))
+	rand.Seed(seed)
 	return c.Next(), nil
 }
 


### PR DESCRIPTION
Lua 5.4 changes the implementation of math.randomseed (can have 0 or 2 arguments).

See https://www.lua.org/manual/5.4/manual.html#pdf-math.randomseed

This PR implements the above as far as possible (seeds are only 64 bits in Go)