### PR TITLE
Infinite floats quote to huge float literals

### DIFF
--- a/lib/stringlib/format.go
+++ b/lib/stringlib/format.go
@@ -2,6 +2,7 @@ package stringlib
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"unsafe"
 
@@ -215,7 +216,17 @@ func quote(v rt.Value) (string, bool) {
 	case rt.IntType:
 		return strconv.Itoa(int(v.AsInt())), true
 	case rt.FloatType:
-		return strconv.FormatFloat(v.AsFloat(), 'g', -1, 64), true
+		x := v.AsFloat()
+		if math.IsInf(x, 0) {
+			// Use an out of range literal to represent infinity.  It works
+			// because that parses to infinity
+			if x > 0 {
+				return "1e9999", true
+			} else {
+				return "-1e9999", true
+			}
+		}
+		return strconv.FormatFloat(x, 'g', -1, 64), true
 	case rt.BoolType:
 		return strconv.FormatBool(v.AsBool()), true
 	case rt.StringType:

--- a/lib/stringlib/lua/stringlib.lua
+++ b/lib/stringlib/lua/stringlib.lua
@@ -336,6 +336,9 @@ do
     print(ps(pf) == ps(ps))
     --> =false
 
+    -- In Lua 5.4 infinite floats parse to out of range float literals
+    pf("%q,%q", math.huge, -math.huge)
+    --> =1e9999,-1e9999
 end
 
 do


### PR DESCRIPTION
Lua 5.4 implementation changes the "%q" formatting of infinite floats, instead of "inf" / "-inf" they format to "1e9999" / "-1e9999".  This is not documented.

This PR makes the change in golua