### PR TITLE
Lua 5.4 forbid modifiers for %q specifier in format strings

### DIFF
--- a/lib/stringlib/format.go
+++ b/lib/stringlib/format.go
@@ -53,6 +53,7 @@ OuterLoop:
 	for i := 0; i < len(format); i++ {
 		if format[i] == '%' {
 			var (
+				start        = i + 1
 				arg          interface{}
 				length, prec int
 				foundDot     bool
@@ -128,6 +129,9 @@ OuterLoop:
 					break ArgLoop
 				case 'q':
 					// quote, only for literals I think
+					if start < i {
+						return "", rt.NewErrorS("specifier '%q' cannot have modifiers")
+					}
 					if len(args) <= j {
 						return "", errNotEnoughValues
 					}

--- a/lib/stringlib/lua/stringlib.lua
+++ b/lib/stringlib/lua/stringlib.lua
@@ -259,6 +259,9 @@ do
     pf("%q %q %q", false, 1, 1.5)
     --> =false 1 1.5
 
+    print(pcall(pf, "%10q", 2))
+    --> ~false\t.*cannot have modifiers
+
     errf("%t")
     --> ~not enough values
 


### PR DESCRIPTION
Since Lua 5.4, e.g. string.format("%10q", 1) returns an error (this is an undocumented change AFAICT, but tested in the Lua 5.4 Test Suite)

This PR implements the above and adds Lua tests for it.
