### PR TITLE
Lua 5.4 unicode support

### DIFF
--- a/ast/string.go
+++ b/ast/string.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 
+	"github.com/arnodel/golua/luastrings"
 	"github.com/arnodel/golua/token"
 )
 
@@ -98,12 +99,11 @@ func replaceEscapeSeq(e []byte) []byte {
 	case 'u', 'U':
 		i, err := strconv.ParseInt(string(e[3:len(e)-1]), 16, 32)
 		if err != nil {
-			panic(err)
-		}
-		if i >= 0x110000 {
 			panic(fmt.Errorf("unicode escape sequence out of range near '%s'", e))
 		}
-		return []byte(string(rune(i)))
+		var p [6]byte
+		n := luastrings.UTF8EncodeInt32(p[:], int32(i))
+		return p[:n]
 	default:
 		return e[1:]
 	}

--- a/lib/utf8lib/lua/utf8lib.lua
+++ b/lib/utf8lib/lua/utf8lib.lua
@@ -26,7 +26,12 @@ do
     print(pcall(utf8.char, -1, "hello", 100))
     --> ~false	.*out of range
 
-    print(pcall(utf8.char, 0x110000, "hello", 100))
+    -- Encoding is lax since Lua 5.4
+
+    print(pcall(utf8.char, 0x7fffffff, "hello", 100))
+    --> ~false	.*should be an integer
+
+    print(pcall(utf8.char, 0x80000000, "hello", 100))
     --> ~false	.*out of range
     
 end

--- a/lib/utf8lib/lua/utf8lib.lua
+++ b/lib/utf8lib/lua/utf8lib.lua
@@ -52,6 +52,18 @@ do
 
     print(pcall(iter))
     --> ~false	.*invalid UTF-8 code
+
+    -- lax mode (Lua 5.4)
+    for p, c in utf8.codes("\u{200000}\u{3FFFFFF}\u{4000000}\u{7FFFFFFF}", true) do
+        print(p, string.format("%x", c))
+    end
+    --> =1	200000
+    --> =6	3ffffff
+    --> =11	4000000
+    --> =17	7fffffff
+
+    print(pcall(utf8.codes, "abc", "123"))
+    --> ~false\t.*must be a boolean
 end
 
 do
@@ -86,6 +98,13 @@ do
 
     err("ab\xff", 3)
     --> ~invalid UTF-8 code
+
+    -- Check "non-strict" unicode (Lua 5.4)
+    print(pcall(utf8.codepoint, "\u{7FFFFFFF}"))
+    --> ~false\t.*invalid UTF-8 code
+
+    print(utf8.codepoint("\u{7FFFFFFF}", 1, 1, true) == 0x7FFFFFFF)
+    --> =true
 end
 
 do
@@ -117,6 +136,14 @@ do
 
     err("ABC", 2, {})
     --> ~must be an integer
+
+    -- lax mode (Lua 5.4)
+
+    err("sdfjl", 2, 4, "true")
+    --> ~must be a boolean
+
+    print(utf8.len("\u{200000}\u{3FFFFFF}\u{4000000}\u{7FFFFFFF}", 1, -1, true))
+    --> =4
 end
 
 do

--- a/lib/utf8lib/utf8lib.go
+++ b/lib/utf8lib/utf8lib.go
@@ -2,6 +2,7 @@ package utf8lib
 
 import (
 	"errors"
+	"math"
 	"unicode/utf8"
 
 	"github.com/arnodel/golua/lib/packagelib"
@@ -34,7 +35,7 @@ func load(r *rt.Runtime) (rt.Value, func()) {
 
 func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	runes := c.Etc()
-	maxLen := len(runes) * utf8.UTFMax
+	maxLen := len(runes) * luastrings.UTFMax
 	t.RequireBytes(maxLen)
 	buf := make([]byte, maxLen)
 	cur := buf
@@ -45,10 +46,10 @@ func char(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 		if !ok {
 			return nil, rt.NewErrorF("#%d should be an integer", i+1)
 		}
-		if n < 0 || n > 0x10FFFF {
+		if n < 0 || n > math.MaxInt32 {
 			return nil, rt.NewErrorF("#%d value out of range", i+1)
 		}
-		sz := utf8.EncodeRune(cur, rune(n))
+		sz := luastrings.UTF8EncodeInt32(cur, int32(n))
 		cur = cur[sz:]
 		bufLen += sz
 	}

--- a/lib/utf8lib/utf8lib.go
+++ b/lib/utf8lib/utf8lib.go
@@ -18,7 +18,7 @@ var LibLoader = packagelib.Loader{
 
 func load(r *rt.Runtime) (rt.Value, func()) {
 	pkg := rt.NewTable()
-	r.SetEnv(pkg, "charpattern", rt.StringValue("[\x00-\x7F\xC2-\xF4][\x80-\xBF]*"))
+	r.SetEnv(pkg, "charpattern", rt.StringValue("[\x00-\x7F\xC2-\xFD][\x80-\xBF]*"))
 
 	rt.SolemnlyDeclareCompliance(
 		rt.ComplyCpuSafe|rt.ComplyMemSafe|rt.ComplyTimeSafe|rt.ComplyIoSafe,

--- a/luastrings/escape.go
+++ b/luastrings/escape.go
@@ -8,27 +8,26 @@ import (
 
 var names = []byte("abtnvf")
 
-func Quote(s string, quote rune) string {
+// Quote a string so that it is a valid Lua string literal
+func Quote(s string, quote byte) string {
 	var b strings.Builder
-	b.WriteRune(quote)
-	for _, r := range s {
+	b.WriteByte(quote)
+	for _, c := range []byte(s) {
 		switch {
-		case r == quote:
+		case c == quote:
 			b.WriteByte('\\')
-			b.WriteRune(r)
-		case unicode.IsGraphic(r):
-			b.WriteRune(r)
-		case r < 256:
-			b.WriteByte('\\')
-			if r >= 7 && r <= 13 {
-				b.WriteByte(names[r-7])
-			}
-			b.WriteString(strconv.FormatInt(int64(r), 10))
+			b.WriteByte(c)
+		case unicode.IsGraphic(rune(c)):
+			b.WriteByte(c)
 		default:
-			b.Write([]byte("\\x"))
-			b.WriteRune(r)
+			b.WriteByte('\\')
+			if c >= 7 && c <= 13 {
+				b.WriteByte(names[c-7])
+			} else {
+				b.WriteString(strconv.FormatInt(int64(c), 10))
+			}
 		}
 	}
-	b.WriteRune(quote)
+	b.WriteByte(quote)
 	return b.String()
 }

--- a/luastrings/escape_test.go
+++ b/luastrings/escape_test.go
@@ -1,0 +1,56 @@
+package luastrings
+
+import "testing"
+
+func TestQuote(t *testing.T) {
+	type args struct {
+		s     string
+		quote byte
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "single quoted",
+			args: args{
+				s:     `"hi" 'there'`,
+				quote: '\'',
+			},
+			want: `'"hi" \'there\''`,
+		},
+		{
+			name: "double quoted",
+			args: args{
+				s:     `"hi" 'there'`,
+				quote: '"',
+			},
+			want: `"\"hi\" 'there'"`,
+		},
+		{
+			name: "named escapes",
+			args: args{
+				s:     "\a\b\t\n\v\f",
+				quote: '"',
+			},
+			want: `"\a\b\t\n\v\f"`,
+		},
+		{
+			name: "ascii escapes",
+			args: args{
+				s:     "\x00\x01\x7f",
+				quote: '"',
+			},
+			want: `"\0\1\127"`,
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Quote(tt.args.s, tt.args.quote); got != tt.want {
+				t.Errorf("Quote() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/luastrings/escape_test.go
+++ b/luastrings/escape_test.go
@@ -44,7 +44,6 @@ func TestQuote(t *testing.T) {
 			},
 			want: `"\0\1\127"`,
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/luastrings/utf8.go
+++ b/luastrings/utf8.go
@@ -1,5 +1,7 @@
 package luastrings
 
+import "unicode/utf8"
+
 const (
 	t1 = 0b00000000
 	tx = 0b10000000
@@ -10,11 +12,11 @@ const (
 	t6 = 0b11111100
 
 	maskx = 0b00111111
-	// mask2 = 0b00011111
-	// mask3 = 0b00001111
-	// mask4 = 0b00000111
-	// mask5 = 0b00000011
-	// mask6 = 0b00000001
+	mask2 = 0b00011111
+	mask3 = 0b00001111
+	mask4 = 0b00000111
+	mask5 = 0b00000011
+	mask6 = 0b00000001
 
 	rune1Max = 1<<7 - 1
 	rune2Max = 1<<11 - 1
@@ -22,7 +24,60 @@ const (
 	rune4Max = 1<<21 - 1
 	rune5Max = 1<<26 - 1
 	// rune6Max = 1<<31 - 1
+
+	// The default lowest and highest continuation byte.
+	locb = 0b10000000
+	hicb = 0b10111111
+
+	// These names of these constants are chosen to give nice alignment in the
+	// table below. The first nibble is an index into acceptRanges or F for
+	// special one-byte cases. The second nibble is the Rune length or the
+	// Status for the special one-byte case.
+	xx = 0xF1 // invalid: size 1
+	as = 0xF0 // ASCII: size 1
+	s1 = 0x02 // accept 0, size 2
+
+	s2 = 0x13 // accept 1, size 3
+	s3 = 0x03 // accept 0, size 3
+	s4 = 0x23 // accept 2, size 3
+
+	s5 = 0x34 // accept 3, size 4
+	s6 = 0x04 // accept 0, size 4
+	s7 = 0x44 // accept 4, size 4
+
+	// Added for Lua
+	s8 = 0x05 // accept 0, size 5
+	s9 = 0x06 // accept 0, size 6
 )
+
+// first is information about the first byte in a UTF-8 sequence.  This table is
+// copied from the utf8 std library.
+var first = [256]uint8{
+	//   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x00-0x0F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x10-0x1F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x20-0x2F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x30-0x3F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x40-0x4F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x50-0x5F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x60-0x6F
+	as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, as, // 0x70-0x7F
+	//   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, // 0x80-0x8F
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, // 0x90-0x9F
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, // 0xA0-0xAF
+	xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, xx, // 0xB0-0xBF
+	xx, xx, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, // 0xC0-0xCF
+	s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, s1, // 0xD0-0xDF
+	s2, s3, s3, s3, s3, s3, s3, s3, s3, s3, s3, s3, s3, s4, s3, s3, // 0xE0-0xEF
+	s5, s6, s6, s6, s7, s6, s6, s6, s8, s8, s8, s8, s9, s9, xx, xx, // 0xF0-0xFF
+}
+
+// 1111 0xxx: 0xF0-0xF7
+// 1111 10xx: 0xF8-0xFB
+// 1111 110x: 0xFC-0xFD
+
+const RuneError = utf8.RuneError
 
 // Encode a unicode point with value i into a sequence of bytes, writing into p.
 // p must be big enough (length 6 accomodates all values).  Returns the number
@@ -73,4 +128,76 @@ func UTF8EncodeInt32(p []byte, i int32) int {
 		p[5] = tx | byte(i)&maskx
 		return 6
 	}
+}
+
+// GetDecodeRuneInString return a decode function that is strict or lax about
+// the utf8 encoding depending on the value of lax.  For details see the UTF-8
+// support section in the Lua 5.4 manual.
+func GetDecodeRuneInString(lax bool) func(string) (rune, int) {
+	if lax {
+		return DecodeRuneInString
+	} else {
+		return utf8.DecodeRuneInString
+	}
+}
+
+// DecodeRuneInString is like DecodeRune but its input is a string. If s is
+// empty it returns (RuneError, 0). Otherwise, if the encoding is invalid, it
+// returns (RuneError, 1). Both are impossible results for correct, non-empty
+// UTF-8.
+//
+// An encoding is invalid if it is incorrect UTF-8, encodes a rune that is
+// out of range, or is not the shortest possible UTF-8 encoding for the
+// value. No other validation is performed.
+func DecodeRuneInString(s string) (r rune, size int) {
+	n := len(s)
+	if n < 1 {
+		return RuneError, 0
+	}
+	s0 := s[0]
+	x := first[s0]
+	if x >= as {
+		// The following code simulates an additional check for x == xx and
+		// handling the ASCII and invalid cases accordingly. This mask-and-or
+		// approach prevents an additional branch.
+		mask := rune(x) << 31 >> 31 // Create 0x0000 or 0xFFFF.
+		return rune(s[0])&^mask | RuneError&mask, 1
+	}
+	sz := int(x & 7)
+	if n < sz {
+		return RuneError, 1
+	}
+	s1 := s[1]
+	if s1 < locb || hicb < s1 {
+		return RuneError, 1
+	}
+	if sz <= 2 { // <= instead of == to help the compiler eliminate some bounds checks
+		return rune(s0&mask2)<<6 | rune(s1&maskx), 2
+	}
+	s2 := s[2]
+	if s2 < locb || hicb < s2 {
+		return RuneError, 1
+	}
+	if sz <= 3 {
+		return rune(s0&mask3)<<12 | rune(s1&maskx)<<6 | rune(s2&maskx), 3
+	}
+	s3 := s[3]
+	if s3 < locb || hicb < s3 {
+		return RuneError, 1
+	}
+	if sz <= 4 {
+		return rune(s0&mask4)<<18 | rune(s1&maskx)<<12 | rune(s2&maskx)<<6 | rune(s3&maskx), 4
+	}
+	s4 := s[4]
+	if s4 < locb || hicb < s4 {
+		return RuneError, 1
+	}
+	if sz <= 5 {
+		return rune(s0&mask5)<<24 | rune(s1&maskx)<<18 | rune(s2&maskx)<<12 | rune(s3&maskx)<<6 | rune(s4&maskx), 5
+	}
+	s5 := s[5]
+	if s5 < locb || hicb < s5 {
+		return RuneError, 1
+	}
+	return rune(s0&mask6)<<30 | rune(s1&maskx)<<24 | rune(s2&maskx)<<18 | rune(s3&maskx)<<12 | rune(s4&maskx)<<6 | rune(s5&maskx), 6
 }

--- a/luastrings/utf8.go
+++ b/luastrings/utf8.go
@@ -1,0 +1,76 @@
+package luastrings
+
+const (
+	t1 = 0b00000000
+	tx = 0b10000000
+	t2 = 0b11000000
+	t3 = 0b11100000
+	t4 = 0b11110000
+	t5 = 0b11111000
+	t6 = 0b11111100
+
+	maskx = 0b00111111
+	// mask2 = 0b00011111
+	// mask3 = 0b00001111
+	// mask4 = 0b00000111
+	// mask5 = 0b00000011
+	// mask6 = 0b00000001
+
+	rune1Max = 1<<7 - 1
+	rune2Max = 1<<11 - 1
+	rune3Max = 1<<16 - 1
+	rune4Max = 1<<21 - 1
+	rune5Max = 1<<26 - 1
+	// rune6Max = 1<<31 - 1
+)
+
+// Encode a unicode point with value i into a sequence of bytes, writing into p.
+// p must be big enough (length 6 accomodates all values).  Returns the number
+// of bytes written. A non-positive value means an error.
+//
+// Any non-negative int32 can be encoded, that is why the golang utf8 package
+// cannot be used.
+func UTF8EncodeInt32(p []byte, i int32) int {
+	switch {
+	case i < 0:
+		return 0
+	case i <= rune1Max:
+		p[0] = t1 | byte(i)
+		return 1
+	case i <= rune2Max:
+		_ = p[1]
+		p[0] = t2 | byte(i>>6)
+		p[1] = tx | byte(i)&maskx
+		return 2
+	case i <= rune3Max:
+		_ = p[2]
+		p[0] = t3 | byte(i>>12)
+		p[1] = tx | byte(i>>6)&maskx
+		p[2] = tx | byte(i)&maskx
+		return 3
+	case i <= rune4Max:
+		_ = p[3]
+		p[0] = t4 | byte(i>>18)
+		p[1] = tx | byte(i>>12)&maskx
+		p[2] = tx | byte(i>>6)&maskx
+		p[3] = tx | byte(i)&maskx
+		return 4
+	case i <= rune5Max:
+		_ = p[4]
+		p[0] = t5 | byte(i>>24)
+		p[1] = tx | byte(i>>18)&maskx
+		p[2] = tx | byte(i>>12)&maskx
+		p[3] = tx | byte(i>>6)&maskx
+		p[4] = tx | byte(i)&maskx
+		return 5
+	default: // i <= rune6Max:
+		_ = p[5]
+		p[0] = t6 | byte(i>>30)
+		p[1] = tx | byte(i>>24)&maskx
+		p[2] = tx | byte(i>>18)&maskx
+		p[3] = tx | byte(i>>12)&maskx
+		p[4] = tx | byte(i>>6)&maskx
+		p[5] = tx | byte(i)&maskx
+		return 6
+	}
+}

--- a/luastrings/utf8.go
+++ b/luastrings/utf8.go
@@ -3,6 +3,8 @@ package luastrings
 import "unicode/utf8"
 
 const (
+	UTFMax = 6
+
 	t1 = 0b00000000
 	tx = 0b10000000
 	t2 = 0b11000000

--- a/luastrings/utf8_test.go
+++ b/luastrings/utf8_test.go
@@ -1,0 +1,130 @@
+package luastrings
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestUTF8EncodeInt32(t *testing.T) {
+	type want struct {
+		n     int
+		bytes []byte
+	}
+	tests := []struct {
+		name string
+		i    int32
+		want want
+	}{
+		{
+			name: "1 byte",
+			i:    0x55,
+			want: want{
+				n:     1,
+				bytes: []byte{0x55},
+			},
+		},
+		{
+			name: "2 bytes low",
+			i:    0x80,
+			want: want{
+				n:     2,
+				bytes: []byte{0xc2, 0x80},
+			},
+		},
+		{
+			name: "2 bytes high",
+			i:    0x7ff,
+			want: want{
+				n:     2,
+				bytes: []byte{0xdf, 0xbf},
+			},
+		},
+		{
+			name: "3 bytes low",
+			i:    0x800,
+			want: want{
+				n:     3,
+				bytes: []byte{0xe0, 0xa0, 0x80},
+			},
+		},
+		{
+			name: "3 bytes high",
+			i:    0xffff,
+			want: want{
+				n:     3,
+				bytes: []byte{0xef, 0xbf, 0xbf},
+			},
+		},
+		{
+			name: "4 bytes low",
+			i:    0x10000,
+			want: want{
+				n:     4,
+				bytes: []byte{0xf0, 0x90, 0x80, 0x80},
+			},
+		},
+		{
+			name: "4 bytes high",
+			i:    0x1fffff,
+			want: want{
+				n:     4,
+				bytes: []byte{0xf7, 0xbf, 0xbf, 0xbf},
+			},
+		},
+		{
+			name: "5 bytes low",
+			i:    0x200000,
+			want: want{
+				n:     5,
+				bytes: []byte{0xf8, 0x88, 0x80, 0x80, 0x80},
+			},
+		},
+		{
+			name: "5 bytes high",
+			i:    0x3ffffff,
+			want: want{
+				n:     5,
+				bytes: []byte{0xfb, 0xbf, 0xbf, 0xbf, 0xbf},
+			},
+		},
+		{
+			name: "6 bytes low",
+			i:    0x4000000,
+			want: want{
+				n:     6,
+				bytes: []byte{0xfc, 0x84, 0x80, 0x80, 0x80, 0x80},
+			},
+		},
+		{
+			name: "6 bytes high",
+			i:    0x7fffffff,
+			want: want{
+				n:     6,
+				bytes: []byte{0xfd, 0xbf, 0xbf, 0xbf, 0xbf, 0xbf},
+			},
+		},
+		{
+			name: "negative i",
+			i:    -3,
+			want: want{
+				n: 0,
+			},
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p [6]byte
+			n := UTF8EncodeInt32(p[:], tt.i)
+			if n != tt.want.n {
+				t.Errorf("UTF8EncodeInt32() = %v, want %v", n, tt.want.n)
+			}
+			if n > 0 {
+				if !reflect.DeepEqual(p[:n], tt.want.bytes) {
+					t.Errorf("UTF8EncodeInt32() bytes = %v, want %v", p[:n], tt.want.bytes)
+
+				}
+			}
+		})
+	}
+}

--- a/luastrings/utf8_test.go
+++ b/luastrings/utf8_test.go
@@ -110,7 +110,6 @@ func TestUTF8EncodeInt32(t *testing.T) {
 				n: 0,
 			},
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/luastrings/utf8_test.go
+++ b/luastrings/utf8_test.go
@@ -1,128 +1,89 @@
 package luastrings
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 )
 
+type Utf8Map struct {
+	r   rune
+	str string
+}
+
+var utf8map = []Utf8Map{
+	{0x00, "\x00"},
+	{0x55, "\x55"},
+	{0x7f, "\x7f"},
+	{0x80, "\xc2\x80"},
+	{0x7ff, "\xdf\xbf"},
+	{0x800, "\xe0\xa0\x80"},
+	{0xffff, "\xef\xbf\xbf"},
+	{0x10000, "\xf0\x90\x80\x80"},
+	{0x1fffff, "\xf7\xbf\xbf\xbf"},
+	{0x200000, "\xf8\x88\x80\x80\x80"},
+	{0x3ffffff, "\xfb\xbf\xbf\xbf\xbf"},
+	{0x4000000, "\xfc\x84\x80\x80\x80\x80"},
+	{0x7fffffff, "\xfd\xbf\xbf\xbf\xbf\xbf"},
+}
+
 func TestUTF8EncodeInt32(t *testing.T) {
-	type want struct {
-		n     int
-		bytes []byte
-	}
-	tests := []struct {
-		name string
-		i    int32
-		want want
-	}{
-		{
-			name: "1 byte",
-			i:    0x55,
-			want: want{
-				n:     1,
-				bytes: []byte{0x55},
-			},
-		},
-		{
-			name: "2 bytes low",
-			i:    0x80,
-			want: want{
-				n:     2,
-				bytes: []byte{0xc2, 0x80},
-			},
-		},
-		{
-			name: "2 bytes high",
-			i:    0x7ff,
-			want: want{
-				n:     2,
-				bytes: []byte{0xdf, 0xbf},
-			},
-		},
-		{
-			name: "3 bytes low",
-			i:    0x800,
-			want: want{
-				n:     3,
-				bytes: []byte{0xe0, 0xa0, 0x80},
-			},
-		},
-		{
-			name: "3 bytes high",
-			i:    0xffff,
-			want: want{
-				n:     3,
-				bytes: []byte{0xef, 0xbf, 0xbf},
-			},
-		},
-		{
-			name: "4 bytes low",
-			i:    0x10000,
-			want: want{
-				n:     4,
-				bytes: []byte{0xf0, 0x90, 0x80, 0x80},
-			},
-		},
-		{
-			name: "4 bytes high",
-			i:    0x1fffff,
-			want: want{
-				n:     4,
-				bytes: []byte{0xf7, 0xbf, 0xbf, 0xbf},
-			},
-		},
-		{
-			name: "5 bytes low",
-			i:    0x200000,
-			want: want{
-				n:     5,
-				bytes: []byte{0xf8, 0x88, 0x80, 0x80, 0x80},
-			},
-		},
-		{
-			name: "5 bytes high",
-			i:    0x3ffffff,
-			want: want{
-				n:     5,
-				bytes: []byte{0xfb, 0xbf, 0xbf, 0xbf, 0xbf},
-			},
-		},
-		{
-			name: "6 bytes low",
-			i:    0x4000000,
-			want: want{
-				n:     6,
-				bytes: []byte{0xfc, 0x84, 0x80, 0x80, 0x80, 0x80},
-			},
-		},
-		{
-			name: "6 bytes high",
-			i:    0x7fffffff,
-			want: want{
-				n:     6,
-				bytes: []byte{0xfd, 0xbf, 0xbf, 0xbf, 0xbf, 0xbf},
-			},
-		},
-		{
-			name: "negative i",
-			i:    -3,
-			want: want{
-				n: 0,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tt := range utf8map {
+		t.Run(fmt.Sprintf("%x", tt.r), func(t *testing.T) {
 			var p [6]byte
-			n := UTF8EncodeInt32(p[:], tt.i)
-			if n != tt.want.n {
-				t.Errorf("UTF8EncodeInt32() = %v, want %v", n, tt.want.n)
+			n := UTF8EncodeInt32(p[:], tt.r)
+			if n != len(tt.str) {
+				t.Errorf("UTF8EncodeInt32() = %v, want %v", n, len(tt.str))
 			}
 			if n > 0 {
-				if !reflect.DeepEqual(p[:n], tt.want.bytes) {
-					t.Errorf("UTF8EncodeInt32() bytes = %v, want %v", p[:n], tt.want.bytes)
+				if !reflect.DeepEqual(p[:n], []byte(tt.str)) {
+					t.Errorf("UTF8EncodeInt32() bytes = %v, want %v", p[:n], []byte(tt.str))
 
 				}
+			}
+		})
+	}
+	t.Run(fmt.Sprintf("%x", -1), func(t *testing.T) {
+		var p [6]byte
+		n := UTF8EncodeInt32(p[:], -1)
+		if n != 0 {
+			t.Errorf("UTF8EncodeInt32() = %v, want %v", n, 0)
+		}
+	})
+
+}
+
+func TestDecodeRuneInString(t *testing.T) {
+	for _, tt := range utf8map {
+		t.Run(fmt.Sprintf("%x", tt.r), func(t *testing.T) {
+			gotR, gotSize := DecodeRuneInString(tt.str)
+			if gotR != tt.r {
+				t.Errorf("DecodeRuneInString() gotR = %v, want %v", gotR, tt.r)
+			}
+			if gotSize != len(tt.str) {
+				t.Errorf("DecodeRuneInString() gotSize = %v, want %v", gotSize, len(tt.str))
+			}
+		})
+		t.Run(fmt.Sprintf("byte missing %x", tt.r), func(t *testing.T) {
+			gotR, gotSize := DecodeRuneInString(tt.str[:len(tt.str)-1])
+			if gotR != RuneError {
+				t.Errorf("DecodeRuneInString() gotR = %v, want %v", gotR, tt.r)
+			}
+			wantSize := 1
+			if len(tt.str) == 1 {
+				wantSize = 0
+			}
+			if gotSize != wantSize {
+				t.Errorf("DecodeRuneInString() gotSize = %v, want %v", gotSize, wantSize)
+			}
+		})
+		t.Run(fmt.Sprintf("out of range %x", tt.r), func(t *testing.T) {
+			gotR, gotSize := DecodeRuneInString(tt.str[:len(tt.str)-1] + "\xff")
+			if gotR != RuneError {
+				t.Errorf("DecodeRuneInString() gotR = %v, want %v", gotR, tt.r)
+			}
+			if gotSize != 1 {
+				t.Errorf("DecodeRuneInString() gotSize = %v, want %v", gotSize, 1)
 			}
 		})
 	}

--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -184,6 +184,16 @@ func (c *GoCont) StringArg(n int) (string, *Error) {
 	return s, nil
 }
 
+// BoolArg returns the n-th argument as a string if possible, otherwise a
+// non-nil *Error.  No range check!
+func (c *GoCont) BoolArg(n int) (bool, *Error) {
+	b, ok := c.Arg(n).TryBool()
+	if !ok {
+		return false, NewErrorF("#%d must be a boolean", n+1)
+	}
+	return b, nil
+}
+
 // CallableArg returns the n-th argument as a callable if possible, otherwise a
 // non-nil *Error.  No range check!
 func (c *GoCont) CallableArg(n int) (Callable, *Error) {

--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -187,7 +187,11 @@ func (c *GoCont) StringArg(n int) (string, *Error) {
 // BoolArg returns the n-th argument as a string if possible, otherwise a
 // non-nil *Error.  No range check!
 func (c *GoCont) BoolArg(n int) (bool, *Error) {
-	b, ok := c.Arg(n).TryBool()
+	arg := c.Arg(n)
+	if arg.IsNil() {
+		return false, nil
+	}
+	b, ok := arg.TryBool()
 	if !ok {
 		return false, NewErrorF("#%d must be a boolean", n+1)
 	}


### PR DESCRIPTION
Lua 5.4 introduces support for non-standard unicode code points, including utf8 support for them.  Quoting from the docs:

>The UTF-8 encoding of a Unicode character can be inserted in a literal string with the escape sequence \u{XXX} (with mandatory enclosing braces), where XXX is a sequence of one or more hexadecimal digits representing the character code point. This code point can be any value less than 231. (Lua uses the original UTF-8 specification here, which is not restricted to valid Unicode code points.)

The above is implemented in this PR

Also the utf8 decoding functions acquire a "lax" mode allowing decoding any value encoded as above.  See the section on UTF-8 in the Lua docs, or the tests in this PR.
