### PR TITLE
Ensure constant upvalues are enforced

### DIFF
--- a/ir/builder.go
+++ b/ir/builder.go
@@ -107,12 +107,14 @@ func (c *CodeBuilder) getRegister(name Name, tags uint) (reg Register, ok bool) 
 	}
 	reg, ok = c.parent.getRegister(name, regHasUpvalue)
 	if ok {
+		isConstant := c.parent.IsConstantReg(reg)
 		c.parent.registers[reg].IsCell = true
 		c.upvalues = append(c.upvalues, reg)
 		c.upnames = append(c.upnames, string(name))
 		reg = c.GetFreeRegister()
 		c.upvalueDests = append(c.upvalueDests, reg)
 		c.registers[reg].IsCell = true
+		c.registers[reg].IsConstant = isConstant
 		c.context.addToRoot(name, reg)
 	}
 	return

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -42,6 +42,16 @@ test[[
 ]]
 --> ~false\t.*attempt to reassign constant variable 'bar'
 
+test[[
+    local x <const> = 2
+    local function foo()
+        x = 3
+        return x
+    end
+    return foo()
+]]
+--> ~false\t.*attempt to reassign constant variable 'x'
+
 --
 -- to-be-closed tests
 --


### PR DESCRIPTION
There is a bug in the implementation of local <const>: constant upvalues can be modified in closures containing these upvalues (see example in PR code)

The fix is to make sure the IsConstant property of registers is propagated.