### PR TITLE
Fix tail calls in to be closed context

### DIFF
--- a/astcomp/compstat.go
+++ b/astcomp/compstat.go
@@ -351,7 +351,7 @@ func (c *compiler) compileBlockNoPop(s ast.BlockStat, complete bool) func() {
 		c.CompileStat(stat)
 	}
 	if s.Return != nil {
-		if fc, ok := tailCall(s.Return); ok {
+		if fc, ok := c.getTailCall(s.Return); ok {
 			c.compileCall(*fc.BFunctionCall, true)
 		} else {
 			contReg := c.getCallerReg()
@@ -400,8 +400,8 @@ func getBackLabels(c *ir.CodeBuilder, statements []ast.Stat) int {
 	return count
 }
 
-func tailCall(rtn []ast.ExpNode) (ast.FunctionCall, bool) {
-	if len(rtn) != 1 {
+func (c *compiler) getTailCall(rtn []ast.ExpNode) (ast.FunctionCall, bool) {
+	if len(rtn) != 1 || c.HasPendingCloseActions() {
 		return ast.FunctionCall{}, false
 	}
 	fc, ok := rtn[0].(ast.FunctionCall)

--- a/ir/builder.go
+++ b/ir/builder.go
@@ -173,6 +173,13 @@ func (c *CodeBuilder) PushCloseAction(reg Register) {
 	c.EmitNoLine(PushCloseStack{Src: reg})
 }
 
+// HasPendingCloseActions returns true if there are close actions in the current
+// context.  In this case tail calls are disabled in order to allow the close
+// actions to take place after the call.
+func (c *CodeBuilder) HasPendingCloseActions() bool {
+	return c.context.getHeight() > 0
+}
+
 func (c *CodeBuilder) emitTruncate(m lexicalScope) {
 	if m.height < c.context.top().height {
 		c.EmitNoLine(TruncateCloseStack{Height: m.height})

--- a/ir/context.go
+++ b/ir/context.go
@@ -88,6 +88,13 @@ func (c lexicalContext) addHeight(h int) (ok bool) {
 	return ok
 }
 
+func (c lexicalContext) getHeight() int {
+	if len(c) > 0 {
+		return c[len(c)-1].height
+	}
+	return 0
+}
+
 // pushNew returns a new LexicalContext that extends the receive with a new
 // blank lexical scope.
 func (c lexicalContext) pushNew() lexicalContext {

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -176,4 +176,5 @@ do
     f()
     print(s)
     --> =start+x+y-y-x
+    -- x is closed after y, showing that g() wasn't a tail-call.
 end

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -162,3 +162,18 @@ do
     print(s)
     --> =start+x3+x2+x1+x0-x0-x1-x2-x3
 end
+
+-- Tail calls are disabled when there are pending to-be-closed variables.
+do
+    s = "start"
+    local function g()
+        local y <close> = mk("y")
+    end
+    local function f()
+        local x <close> = mk("x")
+        return g() -- This isn't a tail call
+    end
+    f()
+    print(s)
+    --> =start+x+y-y-x
+end


### PR DESCRIPTION
Although it is not documented, the Lua 5.4 test suite checks that when returning from a function at a point when there are pending to-be-closed variables, tail-calls are disabled so that the closing action can be performed after the call.

e.g.
```lua
function f()
    local x <close> = mkclose()
    return g() -- This would normally be a tail-call
end
```

This PR implements this restriction.
