### PR TITLE
Fix error when missing close metamethod

### DIFF
--- a/lib/coroutine/lua/coroutine.lua
+++ b/lib/coroutine/lua/coroutine.lua
@@ -111,8 +111,9 @@ do
     print(coroutine.status(co))
     --> =dead
     local co = coroutine.create(function()
-        local x <close> = {}
-        setmetatable(x, {__close=function() error("ERR") end})
+        local t = {}
+        setmetatable(t, {__close=function() error("ERR") end})
+        local x <close> = t
         coroutine.yield()
     end)
     coroutine.resume(co)

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -176,6 +176,7 @@ end
 do
     print(pcall(function()
         local x <close> = {}
+        print"we don't get to here"
     end))
     --> ~false\t.*missing a __close metamethod
 end

--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -65,7 +65,7 @@ test[[
 test[[
     local x <close> = 1
 ]]
---> ~false\t.*to be closed variable missing a __close metamethod
+--> ~false\t.*to be closed value missing a __close metamethod
 
 function make(msg, err)
     t = {}
@@ -171,4 +171,11 @@ do
     --> ~false\t.*: stop
     print(s)
     --> =start+x3+x2+x1+x0-x0-x1-x2-x3
+end
+
+do
+    print(pcall(function()
+        local x <close> = {}
+    end))
+    --> ~false\t.*missing a __close metamethod
 end

--- a/runtime/luacont.go
+++ b/runtime/luacont.go
@@ -391,11 +391,16 @@ RunLoop:
 				if opcode.GetF() {
 					// Push to close stack
 					v := getReg(regs, cells, opcode.GetA())
+					if Truth(v) && t.metaGetS(v, "__close").IsNil() {
+						c.pc = pc
+						return nil, NewErrorS("to be closed value missing a __close metamethod")
+					}
 					c.closeStack = append(c.closeStack, v)
 				} else {
 					// Truncate close stack
 					h := int(opcode.GetClStackOffset())
 					if err := c.truncateCloseStack(t, h, nil); err != nil {
+						c.pc = pc
 						return nil, err
 					}
 				}
@@ -537,7 +542,7 @@ func (c *LuaCont) truncateCloseStack(t *Thread, h int, err *Error) *Error {
 		if Truth(v) {
 			closeErr, ok := Metacall(t, v, "__close", []Value{v, err.Value()}, NewTerminationWith(c, 0, false))
 			if !ok {
-				return NewErrorS("to be closed variable missing a __close metamethod")
+				return NewErrorS("to be closed value missing a __close metamethod")
 			}
 			if closeErr != nil {
 				err = closeErr


### PR DESCRIPTION
When defining a to-be-closed variable, if its value doesn't have a __close metamethod it should error