### PR TITLE
Fix order of debug hooks and close actions

### DIFF
--- a/runtime/lua/locals.lua
+++ b/runtime/lua/locals.lua
@@ -172,3 +172,23 @@ do
     print(s)
     --> =start+x3+x2+x1+x0-x0-x1-x2-x3
 end
+
+-- close actions are run before return debug hooks.  The test below shows that
+-- because 'myfunction' is output.
+do
+    local function myfunction()
+        local function close()
+            debug.sethook(function()
+                print(debug.getinfo(2).name)
+            end, "r")
+        end
+        local t = {}
+        setmetatable(t, {__close=close})
+        local x <close> = t
+    end
+    myfunction()
+    --> =sethook
+    --> =close
+    --> =myfunction
+    debug.sethook()
+end


### PR DESCRIPTION
This is unspecified behaviour in Lua 5.4.  The Lua 5.4 Test Suite expects debug hooks on return statements to be executed after the pending to-be-closed actions have been performed.

This PR implements this (with a Lua test)