### PR TITLE
Limit GoFunction call depth to prevent Go stack overflows

### DIFF
--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -95,7 +95,7 @@ func (c *GoCont) RunInThread(t *Thread) (next Cont, err *Error) {
 	defer func() { t.goFunctionCallDepth-- }()
 
 	if t.goFunctionCallDepth > maxGoFunctionCallDepth {
-		return nil, NewErrorS("Go stack overflow")
+		return nil, NewErrorS("stack overflow")
 	}
 	next, err = c.f(t, c)
 	_ = t.triggerReturn(t, c)

--- a/runtime/gocont.go
+++ b/runtime/gocont.go
@@ -90,8 +90,16 @@ func (c *GoCont) RunInThread(t *Thread) (next Cont, err *Error) {
 		return nil, err
 	}
 	t.RequireCPU(1) // TODO: an appropriate amount
+
+	t.goFunctionCallDepth++
+	defer func() { t.goFunctionCallDepth-- }()
+
+	if t.goFunctionCallDepth > maxGoFunctionCallDepth {
+		return nil, NewErrorS("Go stack overflow")
+	}
 	next, err = c.f(t, c)
 	_ = t.triggerReturn(t, c)
+
 	if err != nil {
 		// If there is an error, c is still potentially needed for error
 		// handling, so do not return it to the pool.  It will get GCed when no

--- a/runtime/lua/godepth.lua
+++ b/runtime/lua/godepth.lua
@@ -1,0 +1,28 @@
+-- Tests for measures agains irrecoverable stack overflows
+
+-- Recursive table.sort
+do
+    local n = 0
+    local x = {}
+    setmetatable(x, {__lt=function(x, y)
+        n = n + 1
+        table.sort{x, y}
+    end})
+    print(pcall(table.sort, {x, x}))
+    --> ~false\t.*stack overflow
+    print(n <= 1000 and n >= 900)
+    --> =true
+end
+
+-- Recursive string.gsub
+do
+    local n = 0
+    local function f()
+        n = n + 1
+        string.gsub("x", ".", f)
+    end
+    print(pcall(f))
+    --> ~false\t.*stack overflow
+    print(n <= 1000 and n >= 900)
+    --> =true
+end

--- a/runtime/thread.go
+++ b/runtime/thread.go
@@ -15,6 +15,10 @@ const (
 	ThreadDead      ThreadStatus = 3 // Thread has finished and cannot be resumed
 )
 
+// The depth of GoFunction calls in one thread is limited by this number in
+// order to avoid irrecoverable Go stack overflows.
+const maxGoFunctionCallDepth = 1000
+
 type valuesError struct {
 	args     []Value
 	err      *Error
@@ -33,6 +37,13 @@ type Thread struct {
 	currentCont Cont
 	resumeCh    chan valuesError
 	caller      *Thread
+
+	// Depth of GoFunction calls in the thread.  This should not exceed
+	// maxGoFunctionCallDepth.  The aim is to avoid Go stack overflows that
+	// cannot be recovered from (note that this does not limit recursion for Lua
+	// functions).
+	goFunctionCallDepth int
+
 	DebugHooks
 }
 


### PR DESCRIPTION
It is possible to contrive some Lua code so that Go Functions recursively call themselves (see the examples in the PR).  This can lead to Go stack overflows, which cannot be recovered from.  To prevent this, limit the GoFunction call depth.

Note that the Lua runtime was already protected (at least to an extent) in a restricted execution environment.  This offers protection in any situation.