### PR TITLE
Only allocate a string if substitutions were made

### DIFF
--- a/lib/stringlib/matching.go
+++ b/lib/stringlib/matching.go
@@ -340,11 +340,6 @@ func gsub(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 		}
 		allowEmpty = start >= end
 		if allowEmpty {
-			// if start < len(s) {
-			// 	t.RequireBytes(1)
-			// 	_ = sb.WriteByte(s[start])
-			// 	sj += 1
-			// }
 			si = start + 1
 		} else {
 			si = end


### PR DESCRIPTION
The Lua `string.gsub` function makes substitutions in a string.  The method for making a substitution can specify that no substitution should be made for a match.  If that happens for all the matches, then it is valid to return the input string unchanged as a result, saving a string allocation.

This is an optimization that the Lua 5.4 Test Suite checks.  It is implemented in this PR.

(it could be backported to the master branch)