### PR TITLE
Lua 5.4 new debug upvalueid return value

### DIFF
--- a/lib/debuglib/debuglib.go
+++ b/lib/debuglib/debuglib.go
@@ -178,7 +178,7 @@ func upvalueid(t *rt.Thread, c *rt.GoCont) (rt.Cont, *rt.Error) {
 	}
 	up := int(upv) - 1
 	if up < 0 || up >= int(f.Code.UpvalueCount) {
-		return nil, rt.NewErrorS("Invalid upvalue index")
+		return c.PushingNext1(t.Runtime, rt.NilValue), nil
 	}
 	return c.PushingNext1(t.Runtime, rt.LightUserDataValue(rt.LightUserData{Data: f.Upvalues[up]})), nil
 }

--- a/lib/debuglib/lua/upvalues.lua
+++ b/lib/debuglib/lua/upvalues.lua
@@ -125,7 +125,7 @@ do
     --> ~.*: Invalid upvalue index
 end
 
--- upvalueid teests
+-- upvalueid tests
 do
     local f1, f2
     local function outer(x, y, z)
@@ -159,9 +159,9 @@ do
     perr(id, f1, nil)
     --> ~.*: #2 must be an integer
 
-    perr(id, f1, 0)
-    --> ~.*: Invalid upvalue index
+    print(id(f1, 0))
+    --> =nil
 
-    perr(id, f1, 4)
-    --> ~.*: Invalid upvalue index
+    print(id(f1, 4))
+    --> =nil
 end


### PR DESCRIPTION
In Lua 5.3 when there was no upvalue for the given index, `debug.upvalueid` used to return an error.  In Lua 5.4 it returns nil.

This PR implements that.