### PR TITLE
No backlabels in a block with return

### DIFF
--- a/runtime/lua/goto.lua
+++ b/runtime/lua/goto.lua
@@ -18,3 +18,11 @@ print(load([[
   until xuxu < x
 ]]))
 --> ~nil\t.*undefined label 'cont'
+
+-- (bugfix) A return statement prevents back labels
+print(load[[
+  goto L
+  local a = 1
+  ::L:: return a
+]])
+--> ~nil\t.*undefined label 'L'


### PR DESCRIPTION
Labels at the end of a statement are called "back-labels", as a special case these can be jumped to even if there is a local variable declaration in the block between the goto statement and the label declaration. E.g.

```lua
do
    goto L
    local a = 2
    ::L::
end
```

There is a bug in label declaration processing which means this is allowed erroneously if the block end in a `return` statement, i.e.

```lua
do
    goto L
    local a = 2
    ::L::  return a
end
```

This PR disallows the latter.
