### PR TITLE
Implement new Lua 5.4 math random modes

### DIFF
--- a/lib/mathlib/lua/mathlib.lua
+++ b/lib/mathlib/lua/mathlib.lua
@@ -197,10 +197,15 @@ do
     print((pcall(math.random, 2, 1)))
     --> =false
 
-    print(pcall(math.random, -1, math.maxinteger))
-    --> ~false\t.*: interval too large
-
     print(math.random(0, math.maxinteger) >= 0)
+    --> =true
+
+    -- New in Lua 5.4
+    print(math.random(0) == math.random(0))
+    --> =false
+
+    -- Any interval works
+    print(math.random(-1, math.maxinteger) >= -1)
     --> =true
 end
 


### PR DESCRIPTION
Lua 5.4 introduce 2 new modes for math.random

math.random(0) -> a uniformly distributed int64
math.random(a, b) now has no restrictions (as long as a <= b)

Those are implemented in this PR