### PR TITLE
Implement the file __close metamethod

### DIFF
--- a/lib/iolib/lua/iolib.lua
+++ b/lib/iolib/lua/iolib.lua
@@ -275,8 +275,10 @@ do
     --> ~nil\t.*cannot close standard file
 end
 
+local ff
 do
-    local f = io.open("files/writetest3.txt", "w")
+    local f <close> = io.open("files/writetest3.txt", "w")
+    ff = f
     -- hard to test what it does, at least make sure the correct modes are accepted
     f:setvbuf("no")
     f:setvbuf("full")
@@ -306,4 +308,14 @@ do
 
     perr("full", {})
     --> ~false\t.*#3 must be an integer
+
+    -- ff is still open at this point
+    print(io.type(ff))
+    --> =file
 end
+
+-- New in Lua 5.4:
+-- the __close metamethod was called, so ff should be closed now.
+print(io.type(ff))
+--> =closed file
+

--- a/lib/iolib/lua/iolib.lua
+++ b/lib/iolib/lua/iolib.lua
@@ -275,7 +275,7 @@ do
     --> ~nil\t.*cannot close standard file
 end
 
-local ff
+local ff -- this is to remember the file f below refers to after f goes out of scope.
 do
     local f <close> = io.open("files/writetest3.txt", "w")
     ff = f
@@ -319,3 +319,12 @@ end
 print(io.type(ff))
 --> =closed file
 
+do
+    local close = getmetatable(ff).__close
+
+    print(pcall(close))
+    --> ~false\t.*value needed
+
+    print(pcall(close, {}))
+    --> ~false\t.*#1 must be a file
+end


### PR DESCRIPTION
In Lua 5.4 files have a __close metamethod that closes a file when it goes out of scope e.g.:

```lua
do
    local f <close> = io.open("hello")
    -- do stuff
end
-- At this point the file is closed for sure, even if not garbage-collected
```

This PR implements this metamethod