### PR TITLE
Better handling of expressions in repl

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -199,11 +199,7 @@ func (c *luaCmd) repl(r *rt.Runtime) int {
 		if err != nil {
 			return fatal("error: %s", err)
 		}
-		// This is a trick to be able to evaluate lua expressions in the repl
-		more, err := c.runChunk(r, append([]byte("return "), w.Bytes()...))
-		if err != nil {
-			more, err = c.runChunk(r, w.Bytes())
-		}
+		more, err := c.runChunk(r, w.Bytes())
 		if !more {
 			w = new(bytes.Buffer)
 			if err != nil {
@@ -233,7 +229,7 @@ func (c *luaCmd) runChunk(r *rt.Runtime, source []byte) (more bool, err error) {
 			more = false
 		}
 	}()
-	clos, err := r.CompileAndLoadLuaChunk("<stdin>", source, rt.TableValue(r.GlobalEnv()))
+	clos, err := r.CompileAndLoadLuaChunkOrExp("<stdin>", source, rt.TableValue(r.GlobalEnv()))
 	if err != nil {
 		snErr, ok := err.(*rt.SyntaxError)
 		if !ok {

--- a/cmd.go
+++ b/cmd.go
@@ -231,11 +231,7 @@ func (c *luaCmd) runChunk(r *rt.Runtime, source []byte) (more bool, err error) {
 	}()
 	clos, err := r.CompileAndLoadLuaChunkOrExp("<stdin>", source, rt.TableValue(r.GlobalEnv()))
 	if err != nil {
-		snErr, ok := err.(*rt.SyntaxError)
-		if !ok {
-			return false, err
-		}
-		return snErr.IsUnexpectedEOF(), err
+		return rt.ErrorIsUnexpectedEOF(err), err
 	}
 	t := r.MainThread()
 	term := rt.NewTerminationWith(nil, 0, true)

--- a/lib/golib/govalue_test.go
+++ b/lib/golib/govalue_test.go
@@ -82,6 +82,21 @@ func Test_reflectToValue(t *testing.T) {
 			arg:  testStruct,
 			want: rt.UserDataValue(rt.NewUserData(testStruct, meta)),
 		},
+		{
+			name: "nil slice",
+			arg:  ([]int)(nil),
+			want: rt.NilValue,
+		},
+		{
+			name: "nil pointer",
+			arg:  (*int)(nil),
+			want: rt.NilValue,
+		},
+		{
+			name: "nil interface",
+			arg:  (interface{ Foo() })(nil),
+			want: rt.NilValue,
+		},
 		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
@@ -221,6 +236,11 @@ func Test_valueToType(t *testing.T) {
 			name: "rt.String to []byte",
 			v:    "foo",
 			want: []byte("foo"),
+		},
+		{
+			name: "runtime.Value to runtime.Value",
+			v:    rt.IntValue(10),
+			want: rt.IntValue(10),
 		},
 		// TODO: Add test cases.
 	}

--- a/lib/golib/lua/golib.lua
+++ b/lib/golib/lua/golib.lua
@@ -71,3 +71,13 @@ do
     print(sprintf("-%s-", "hello"))
 end
 --> =-hello-
+
+print(pcall(ben))
+--> ~false\t.*not a function
+
+print(pcall(double, {}))
+--> ~false\t.*cannot be converted to int
+
+-- No argument defaults to the zero value
+print(double())
+--> =0

--- a/runtime/lib.go
+++ b/runtime/lib.go
@@ -282,14 +282,30 @@ func (r *Runtime) ParseLuaChunk(name string, source []byte, scannerOptions ...sc
 	return
 }
 
-// CompileLuaChunk parses and compiles the source as a Lua Chunk and returns the
-// compile code Unit.
-func (r *Runtime) CompileLuaChunk(name string, source []byte, scannerOptions ...scanner.Option) (*code.Unit, uint64, error) {
-	stat, statSize, err := r.ParseLuaChunk(name, source, scannerOptions...)
-	if err != nil {
-		return nil, 0, err
-	}
+// ParseLuaExp parses a string as a Lua expression and returns the AST.
+func (r *Runtime) ParseLuaExp(name string, source []byte, scannerOptions ...scanner.Option) (stat *ast.BlockStat, statSize uint64, err error) {
+	s := scanner.New(name, source, scannerOptions...)
 
+	// Account for CPU and memory used to make the AST.  This is an estimate,
+	// but statSize is proportional to the size of the source.
+	statSize = uint64(len(source))
+	r.LinearRequire(4, uint64(len(source))) // 4 is a factor pulled out of thin air
+
+	exp, err := parsing.ParseExp(s)
+	if err != nil {
+		r.ReleaseMem(statSize)
+		parseErr, ok := err.(parsing.Error)
+		if !ok {
+			return nil, 0, err
+		}
+		return nil, 0, NewSyntaxError(name, parseErr)
+	}
+	stat = new(ast.BlockStat)
+	*stat = ast.NewBlockStat(nil, []ast.ExpNode{exp})
+	return
+}
+
+func (r *Runtime) compileLuaStat(name string, stat *ast.BlockStat, statSize uint64) (*code.Unit, uint64, error) {
 	// In any event the AST goes out of scope when leaving this function
 	defer func() { r.ReleaseMem(statSize) }()
 
@@ -333,6 +349,52 @@ func (r *Runtime) CompileLuaChunk(name string, source []byte, scannerOptions ...
 
 	// We no longer need the constants
 	return unit, unitSize, nil
+}
+
+func (r *Runtime) CompileLuaChunkOrExp(name string, source []byte, scannerOptions ...scanner.Option) (unit *code.Unit, sz uint64, err error) {
+	var statErr error
+	stat, statSize, expErr := r.ParseLuaExp(name, source, scannerOptions...)
+	if expErr != nil {
+		stat, statSize, statErr = r.ParseLuaChunk(name, source, scannerOptions...)
+	}
+	if expErr != nil && statErr != nil {
+		// If parsing as expression or chunk failed, then try to return the error that showed the most parsing
+		expSyntaxErr, okExp := expErr.(*SyntaxError)
+		statSyntaxErr, okStat := statErr.(*SyntaxError)
+		switch {
+		case !okStat:
+			err = expErr
+		case !okExp:
+			err = statErr
+		case expSyntaxErr.Err.Got.Pos.Offset >= statSyntaxErr.Err.Got.Offset:
+			err = expErr
+		default:
+			err = statErr
+		}
+		return
+	}
+	return r.compileLuaStat(name, stat, statSize)
+}
+
+// CompileLuaChunk parses and compiles the source as a Lua Chunk and returns the
+// compile code Unit.
+func (r *Runtime) CompileLuaChunk(name string, source []byte, scannerOptions ...scanner.Option) (*code.Unit, uint64, error) {
+	stat, statSize, err := r.ParseLuaChunk(name, source, scannerOptions...)
+	if err != nil {
+		return nil, 0, err
+	}
+	return r.compileLuaStat(name, stat, statSize)
+}
+
+// CompileAndLoadLuaChunk parses, compiles and loads a Lua chunk from source and
+// returns the closure that runs the chunk in the given global environment.
+func (r *Runtime) CompileAndLoadLuaChunkOrExp(name string, source []byte, env Value, scannerOptions ...scanner.Option) (*Closure, error) {
+	unit, unitSize, err := r.CompileLuaChunkOrExp(name, source, scannerOptions...)
+	defer r.ReleaseMem(unitSize)
+	if err != nil {
+		return nil, err
+	}
+	return r.LoadLuaUnit(unit, env), nil
 }
 
 // CompileAndLoadLuaChunk parses, compiles and loads a Lua chunk from source and

--- a/runtime/lib_test.go
+++ b/runtime/lib_test.go
@@ -1,0 +1,77 @@
+package runtime
+
+import (
+	"os"
+	"testing"
+
+	"github.com/arnodel/golua/scanner"
+)
+
+func TestRuntime_CompileLuaChunkOrExp(t *testing.T) {
+	r := New(os.Stdout)
+	type args struct {
+		name           string
+		source         []byte
+		scannerOptions []scanner.Option
+	}
+	tests := []struct {
+		name              string
+		args              args
+		wantErr           bool
+		wantUnexpectedEOF bool
+	}{
+		{
+			name: "a valid expresssion",
+			args: args{
+				name:   "exp",
+				source: []byte("1+1"),
+			},
+		},
+		{
+			name: "a valid chunk",
+			args: args{
+				name:   "chunk",
+				source: []byte("f()\nprint('hello')"),
+			},
+		},
+		{
+			name: "invalid chunk containing expression",
+			args: args{
+				name:   "nogood",
+				source: []byte("x+2\nprint(z)"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "unfinished expresssion",
+			args: args{
+				name:   "uexp",
+				source: []byte("x+4-"),
+			},
+			wantErr:           true,
+			wantUnexpectedEOF: true,
+		},
+		{
+			name: "unfinished statement",
+			args: args{
+				name:   "ustat",
+				source: []byte("do a = 2"),
+			},
+			wantErr:           true,
+			wantUnexpectedEOF: true,
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := r.CompileLuaChunkOrExp(tt.args.name, tt.args.source, tt.args.scannerOptions...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Runtime.CompileLuaChunkOrExp() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantUnexpectedEOF && !ErrorIsUnexpectedEOF(err) {
+				t.Errorf("Runtime.CompileLuaChunkOrExp() IsUnexpectedEOF = %v, want %v", err, tt.wantUnexpectedEOF)
+			}
+		})
+	}
+}

--- a/runtime/lib_test.go
+++ b/runtime/lib_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/arnodel/golua/scanner"
 )
 
-func TestRuntime_CompileLuaChunkOrExp(t *testing.T) {
+func TestRuntime_CompileAndLoadLuaChunkOrExp(t *testing.T) {
 	r := New(os.Stdout)
 	type args struct {
 		name           string
@@ -64,7 +64,7 @@ func TestRuntime_CompileLuaChunkOrExp(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, _, err := r.CompileLuaChunkOrExp(tt.args.name, tt.args.source, tt.args.scannerOptions...)
+			_, err := r.CompileAndLoadLuaChunkOrExp(tt.args.name, tt.args.source, NilValue, tt.args.scannerOptions...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Runtime.CompileLuaChunkOrExp() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/runtime/syntaxerror.go
+++ b/runtime/syntaxerror.go
@@ -31,3 +31,8 @@ func (e *SyntaxError) Error() string {
 func (e *SyntaxError) IsUnexpectedEOF() bool {
 	return e.Err.Got.Type == token.EOF
 }
+
+func ErrorIsUnexpectedEOF(err error) bool {
+	snErr, ok := err.(*SyntaxError)
+	return ok && snErr.IsUnexpectedEOF()
+}


### PR DESCRIPTION
The minimal repl had a hack to deal with expressions such as '1+1'
This implements a tool in runtime package to handle those more
gracefully