### PR TITLE
Cap soft limits from parent context

### DIFF
--- a/lib/runtimelib/lua/softlimits.quotas.lua
+++ b/lib/runtimelib/lua/softlimits.quotas.lua
@@ -57,11 +57,10 @@ runtime.callcontext({kill={millis=1000}, stop={millis=5000}}, function()
     --> =true
 end)
 
--- soft limits can increase from the parent's soft limit.
+-- soft limits cannot increase from the parent's soft limit.
 runtime.callcontext({stop={cpu=1000}, kill={cpu=2000}}, function()
     runtime.callcontext({stop={cpu=3000}}, function()
-        local l = runtime.context().stop.cpu
-        print( l >= 1500, l <= 2000)
-        --> =true	true
+        print(runtime.context().stop.cpu)
+        --> =1000
     end)
 end)

--- a/quotas.md
+++ b/quotas.md
@@ -133,9 +133,11 @@ cannot be mutated but gives useful information about the execution context.
   any of these limits are reached then the context will be terminated
   immediately, returning execution to the parent context.  Hard limits cannot
   exceed their parent's hard limits.
-- `ctx.stop` returns an object giving the resource soft limits of `ctx`.
-  Soft limits cannot exceed hard limits, but can be increased from the parent's
-  context (TODO: check this behaviour).
+- `ctx.stop` returns an object giving the resource soft limits of `ctx`. Soft
+  limits cannot exceed hard limits, and by default cannot be increased from the
+  parent's soft limits.  In future if there is are clear use-cases for
+  increasing the soft limits from the parent's, another API endpoint can be
+  provided.
 - `ctx.used` returns an object giving the used resources of `ctx`
 - `ctx.flags` returns a string describing the flags that any code running in
   this context has to comply with.  Those flags are `"memsafe"`, `"cpusafe"`,

--- a/runtime/runtimecontextmanager.go
+++ b/runtime/runtimecontextmanager.go
@@ -99,7 +99,7 @@ func (m *runtimeContextManager) PushContext(ctx RuntimeContextDef) {
 	parent := *m
 	m.startTime = now()
 	m.hardLimits = m.hardLimits.Remove(m.usedResources).Merge(ctx.HardLimits)
-	m.softLimits = m.hardLimits.Merge(ctx.SoftLimits)
+	m.softLimits = m.hardLimits.Merge(m.softLimits).Merge(ctx.SoftLimits)
 	m.usedResources = RuntimeResources{}
 	m.requiredFlags |= ctx.RequiredFlags
 


### PR DESCRIPTION
Currently in a runtime context, soft limits are capped by the context's hard limits.   This is does not reflect the situation with hard limits which are capped by the parent's hard limits.  To make it more consistent, this PR caps a context's soft limits by both the parent's soft limits and the context's own hard limits.

The tests have been changed to reflect this.

We can have an API for requesting an increase to the context's soft limits, but as there are no concrete use-cases yet it is probably better to defer this.