### PR TITLE
Add FSActionsChecker and FSAccessRule to safeio

### DIFF
--- a/lib/runtimelib/lua/fsaccess.quotas.lua
+++ b/lib/runtimelib/lua/fsaccess.quotas.lua
@@ -19,7 +19,7 @@ print(err)
 -- Allow only reading files in lua/testfiles/
 local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="r"}}}, function() 
     -- This operation is allowed but the file doesn't exist, so open returns an error
-    local f <close>, err = io.open("lua/testfiles/non-existent-file")
+    local f, err = io.open("lua/testfiles/non-existent-file")
     print(err == nil)
     --> =false
 
@@ -32,9 +32,11 @@ print(err)
 -- Allow all operations apart from creating files in lua/testfiles/
 local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="*", denied="c"}}}, function() 
     -- This is allowed because the file exists
-    local f <close>, err = io.open("lua/testfiles/existing-file.txt", "w")
+    local f, err = io.open("lua/testfiles/existing-file.txt", "w")
     print(err)
     --> =nil
+
+    f:close()
 
     -- This operation fails because file creation is disallowed
     io.open("lua/testfiles/non-existent-file", "w")
@@ -45,9 +47,11 @@ print(err)
 -- Allow all operations in lua/testfiles/
 local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="*"}}}, function() 
     -- This operation succeeds because file creation is allowed
-    local f <close>, err = io.open("lua/testfiles/non-existent-file.txt", "w")
+    local f, err = io.open("lua/testfiles/non-existent-file.txt", "w")
     print(err)
     --> =nil
+
+    f:close()
 
     -- The file can be renamed within lua/testfiles
     print(os.rename("lua/testfiles/non-existent-file.txt", "lua/testfiles/renamed.txt"))

--- a/lib/runtimelib/lua/fsaccess.quotas.lua
+++ b/lib/runtimelib/lua/fsaccess.quotas.lua
@@ -1,0 +1,25 @@
+local ctx, err = runtime.callcontext({fs={{prefix="testfiles/", denied="*"}}}, function()
+    -- This operation is not allowed so an error is thrown
+    io.open("testfiles/file.txt")
+end)
+print(err)
+--> ~.*safeio: operation not allowed
+
+local ctx, err = runtime.callcontext({fs={{prefix="testfiles/", allowed="r"}}}, function() 
+    -- This operation is allowed but the file doesn't exist, so open returns an error
+    f, err = io.open("testfiles/non-existent-file")
+    print(err == nil)
+    --> =false
+
+    -- This operation is not allowed so an error is thrown
+    io.open("testfiles/../otherdir/a-file")
+end)
+print(err)
+--> ~.*safeio: operation not allowed
+
+local ctx, err = runtime.callcontext({fs={{prefix="testfiles/", allowed="*", denied="c"}}}, function() 
+    -- This operation is not allowed because file creation is disallowed
+    io.open("testfiles/non-existent-file", "w")
+end)
+print(err)
+--> ~.*safeio: operation not allowed

--- a/lib/runtimelib/lua/fsaccess.quotas.lua
+++ b/lib/runtimelib/lua/fsaccess.quotas.lua
@@ -1,25 +1,49 @@
 local ctx, err = runtime.callcontext({fs={{prefix="testfiles/", denied="*"}}}, function()
     -- This operation is not allowed so an error is thrown
-    io.open("testfiles/file.txt")
+    io.open("testfiles/existing-file.txt")
 end)
 print(err)
 --> ~.*safeio: operation not allowed
 
-local ctx, err = runtime.callcontext({fs={{prefix="testfiles/", allowed="r"}}}, function() 
+local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="r"}}}, function() 
     -- This operation is allowed but the file doesn't exist, so open returns an error
-    f, err = io.open("testfiles/non-existent-file")
+    local f <close>, err = io.open("lua/testfiles/non-existent-file")
     print(err == nil)
     --> =false
 
     -- This operation is not allowed so an error is thrown
-    io.open("testfiles/../otherdir/a-file")
+    io.open("lua/testfiles/../otherdir/a-file")
 end)
 print(err)
 --> ~.*safeio: operation not allowed
 
-local ctx, err = runtime.callcontext({fs={{prefix="testfiles/", allowed="*", denied="c"}}}, function() 
-    -- This operation is not allowed because file creation is disallowed
-    io.open("testfiles/non-existent-file", "w")
+local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="*", denied="c"}}}, function() 
+    -- This is allowed because the file exists
+    local f <close>, err = io.open("lua/testfiles/existing-file.txt", "w")
+    print(err)
+    --> =nil
+
+    -- This operation fails because file creation is disallowed
+    io.open("lua/testfiles/non-existent-file", "w")
 end)
 print(err)
 --> ~.*safeio: operation not allowed
+
+local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="*"}}}, function() 
+    -- This operation succeeds because file creation is allowed
+    local f <close>, err = io.open("lua/testfiles/non-existent-file.txt", "w")
+    print(err)
+    --> =nil
+
+    -- The file can be renamed within lua/testfiles
+    print(os.rename("lua/testfiles/non-existent-file.txt", "lua/testfiles/renamed.txt"))
+    --> =true
+
+    -- The file cannot be moved outside of lua/testfiles
+    print(pcall(os.rename, "lua/testfiles/renamed.txt", "lua/otherdir/moved.txt"))
+    --> ~false\t.*safeio: operation not allowed
+
+    -- The file can be deleted
+    print(os.remove("lua/testfiles/renamed.txt"))
+    --> =true
+end)

--- a/lib/runtimelib/lua/fsaccess.quotas.lua
+++ b/lib/runtimelib/lua/fsaccess.quotas.lua
@@ -1,3 +1,14 @@
+-- Tests for fs access.  The 'fs' field in the context is a list of rule, each rule of the form
+-- { prefix='prefix/path', allowed=ACTION_STRING, denied=ACTION_STRING }
+-- An ACTION_STRING is a string made of the following characters:
+-- - '*': all actions
+-- - 'r': read a file
+-- - 'w': write a file
+-- - 'c': create a file
+-- - 'd': delete a file
+-- - 'C': create any file in a directory (weird, used for creating temp files)
+
+-- Deny all operations in lua/testfiles/
 local ctx, err = runtime.callcontext({fs={{prefix="testfiles/", denied="*"}}}, function()
     -- This operation is not allowed so an error is thrown
     io.open("testfiles/existing-file.txt")
@@ -5,6 +16,7 @@ end)
 print(err)
 --> ~.*safeio: operation not allowed
 
+-- Allow only reading files in lua/testfiles/
 local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="r"}}}, function() 
     -- This operation is allowed but the file doesn't exist, so open returns an error
     local f <close>, err = io.open("lua/testfiles/non-existent-file")
@@ -17,6 +29,7 @@ end)
 print(err)
 --> ~.*safeio: operation not allowed
 
+-- Allow all operations apart from creating files in lua/testfiles/
 local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="*", denied="c"}}}, function() 
     -- This is allowed because the file exists
     local f <close>, err = io.open("lua/testfiles/existing-file.txt", "w")
@@ -29,6 +42,7 @@ end)
 print(err)
 --> ~.*safeio: operation not allowed
 
+-- Allow all operations in lua/testfiles/
 local ctx, err = runtime.callcontext({fs={{prefix="lua/testfiles/", allowed="*"}}}, function() 
     -- This operation succeeds because file creation is allowed
     local f <close>, err = io.open("lua/testfiles/non-existent-file.txt", "w")

--- a/lib/runtimelib/lua_test.go
+++ b/lib/runtimelib/lua_test.go
@@ -11,5 +11,5 @@ import (
 )
 
 func TestRuntimeLib(t *testing.T) {
-	luatesting.RunLuaTestsInDir(t, "lua", lib.LoadAll)
+	luatesting.RunLuaTestsInDir(t, "lua", lib.LoadAll, "fsaccess")
 }

--- a/lib/runtimelib/runtimelib.go
+++ b/lib/runtimelib/runtimelib.go
@@ -226,9 +226,11 @@ func getFSAccessRule(val rt.Value) (safeio.FSAccessRule, error) {
 		prefix = filepath.Clean(prefix)
 	}
 	return safeio.PrefixFSAccessRule{
-		Prefix:         prefix,
-		AllowedActions: allowed,
-		DeniedActions:  denied,
+		Prefix: prefix,
+		Effect: safeio.FSAccessEffect{
+			AllowedActions: allowed,
+			DeniedActions:  denied,
+		},
 	}, nil
 }
 

--- a/runtime/runtimecontext.go
+++ b/runtime/runtimecontext.go
@@ -1,11 +1,14 @@
 package runtime
 
+import "github.com/arnodel/golua/safeio"
+
 // RuntimeContextDef contains the data necessary to create an new runtime context.
 type RuntimeContextDef struct {
 	HardLimits     RuntimeResources
 	SoftLimits     RuntimeResources
 	RequiredFlags  ComplianceFlags
 	MessageHandler Callable
+	FSAccessRule   safeio.FSAccessRule
 	GCPolicy
 }
 

--- a/runtime/runtimecontextmanager.go
+++ b/runtime/runtimecontextmanager.go
@@ -5,6 +5,7 @@ package runtime
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -320,8 +321,8 @@ func (m *runtimeContextManager) CheckFSActions(path string, requested safeio.FSA
 		return true
 	}
 	if m.fsAccessRule != nil {
-		allowed, denied := m.fsAccessRule.GetFSAccessEffect(path, requested)
-		return denied != 0 && allowed == requested
+		allowed, denied := m.fsAccessRule.GetFSAccessEffect(filepath.Clean(path), requested)
+		return denied == 0 && allowed == requested
 	}
 	return false
 }

--- a/runtime/runtimecontextmanager.go
+++ b/runtime/runtimecontextmanager.go
@@ -135,7 +135,7 @@ func (m *runtimeContextManager) PushContext(ctx RuntimeContextDef) {
 	m.trackMem = m.hardLimits.Memory > 0 || m.softLimits.Memory > 0
 	m.status = StatusLive
 	m.messageHandler = ctx.MessageHandler
-	m.fsAccessRule = safeio.MergeFSAccessRules(parent.fsAccessRule, ctx.FSAccessRule)
+	m.fsAccessRule = safeio.ChainFSAccessRules(parent.fsAccessRule, ctx.FSAccessRule)
 	m.parent = &parent
 	if ctx.GCPolicy == IsolateGCPolicy || ctx.HardLimits.Millis > 0 || ctx.HardLimits.Cpu > 0 || ctx.HardLimits.Memory > 0 {
 		m.weakRefPool = luagc.NewDefaultPool()

--- a/runtime/runtimecontextmanager.go
+++ b/runtime/runtimecontextmanager.go
@@ -321,8 +321,8 @@ func (m *runtimeContextManager) CheckFSActions(path string, requested safeio.FSA
 		return true
 	}
 	if m.fsAccessRule != nil {
-		allowed, denied := m.fsAccessRule.GetFSAccessEffect(filepath.Clean(path), requested)
-		return denied == 0 && allowed == requested
+		effect := m.fsAccessRule.GetFSAccessEffect(filepath.Clean(path), requested)
+		return effect.Allows(requested)
 	}
 	return false
 }

--- a/runtime/runtimecontextmanager_noquotas.go
+++ b/runtime/runtimecontextmanager_noquotas.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"github.com/arnodel/golua/runtime/internal/luagc"
+	"github.com/arnodel/golua/safeio"
 )
 
 const QuotasAvailable = false
@@ -143,4 +144,8 @@ func (m *runtimeContextManager) TerminateContext(format string, args ...interfac
 	panic(ContextTerminationError{
 		message: fmt.Sprintf(format, args...),
 	})
+}
+
+func (m *runtimeContextManager) CheckFSActions(path string, requested safeio.FSAction) bool {
+	return true
 }

--- a/safeio/file.go
+++ b/safeio/file.go
@@ -3,38 +3,84 @@ package safeio
 import (
 	"errors"
 	"io/fs"
-	"io/ioutil"
 	"os"
-
-	rt "github.com/arnodel/golua/runtime"
 )
 
-func OpenFile(r *rt.Runtime, name string, flag int, perm fs.FileMode) (*os.File, error) {
-	if r.RequiredFlags()&rt.ComplyIoSafe != 0 {
+type FSActionsChecker interface {
+	CheckFSActions(path string, actions FSAction) bool
+}
+
+type FSAction uint16
+
+const (
+	ReadFileAction FSAction = 1 << iota
+	WriteFileAction
+	CreateFileAction
+	DeleteFileAction
+	CreateFileInDirAction
+)
+
+func OpenFile(r FSActionsChecker, name string, flag int, perm fs.FileMode) (*os.File, error) {
+	if !r.CheckFSActions(name, osFlagToFSActions(flag)) {
 		return nil, ErrNotAllowed
 	}
 	return os.OpenFile(name, flag, perm)
 }
 
-func TempFile(r *rt.Runtime, dir string, pattern string) (*os.File, error) {
-	if r.RequiredFlags()&rt.ComplyIoSafe != 0 {
+func TempFile(r FSActionsChecker, dir string, pattern string) (*os.File, error) {
+	if !r.CheckFSActions(dir, CreateFileAction) {
 		return nil, ErrNotAllowed
 	}
-	return ioutil.TempFile(dir, pattern)
+	return os.CreateTemp(dir, pattern)
 }
 
-func RemoveFile(r *rt.Runtime, name string) error {
-	if r.RequiredFlags()&rt.ComplyIoSafe != 0 {
+func RemoveFile(r FSActionsChecker, name string) error {
+	if !r.CheckFSActions(name, DeleteFileAction) {
 		return ErrNotAllowed
 	}
 	return os.Remove(name)
 }
 
-func RenameFile(r *rt.Runtime, oldName, newName string) error {
-	if r.RequiredFlags()&rt.ComplyIoSafe != 0 {
+func RenameFile(r FSActionsChecker, oldName, newName string) error {
+	if !r.CheckFSActions(oldName, DeleteFileAction) || !r.CheckFSActions(newName, CreateFileAction) {
 		return ErrNotAllowed
 	}
 	return os.Rename(oldName, newName)
 }
 
+type readFileChecker interface {
+	FSActionsChecker
+	RequireBytes(int) uint64
+}
+
+// ReadFile returns the contents of the file and requires the memory, so is safe
+// to use in memory-constrained environments.
+func ReadFile(r readFileChecker, name string) ([]byte, error) {
+	if !r.CheckFSActions(name, ReadFileAction) {
+		return nil, ErrNotAllowed
+	}
+	fi, err := os.Stat(name)
+	if err != nil {
+		return nil, err
+	}
+	r.RequireBytes(int(fi.Size()))
+	return os.ReadFile(name)
+}
+
 var ErrNotAllowed = errors.New("safeio: operation not allowed")
+
+func osFlagToFSActions(flag int) FSAction {
+	var perms FSAction
+	switch {
+	case flag&os.O_RDONLY != 0:
+		perms |= WriteFileAction
+	case flag&os.O_WRONLY != 0:
+		perms |= ReadFileAction
+	case flag&os.O_RDWR != 0:
+		perms |= ReadFileAction | WriteFileAction
+	}
+	if flag&os.O_CREATE != 0 {
+		perms |= CreateFileAction
+	}
+	return perms
+}

--- a/safeio/file.go
+++ b/safeio/file.go
@@ -20,6 +20,8 @@ const (
 	CreateFileInDirAction
 )
 
+const AllFileActions = ReadFileAction | WriteFileAction | CreateFileAction | DeleteFileAction | CreateFileInDirAction
+
 func OpenFile(r FSActionsChecker, name string, flag int, perm fs.FileMode) (*os.File, error) {
 	if !r.CheckFSActions(name, osFlagToFSActions(flag)) {
 		return nil, ErrNotAllowed
@@ -72,12 +74,12 @@ var ErrNotAllowed = errors.New("safeio: operation not allowed")
 func osFlagToFSActions(flag int) FSAction {
 	var perms FSAction
 	switch {
-	case flag&os.O_RDONLY != 0:
-		perms |= WriteFileAction
 	case flag&os.O_WRONLY != 0:
-		perms |= ReadFileAction
+		perms |= WriteFileAction
 	case flag&os.O_RDWR != 0:
 		perms |= ReadFileAction | WriteFileAction
+	default: // os.O_RDONLY is 0...
+		perms |= ReadFileAction
 	}
 	if flag&os.O_CREATE != 0 {
 		perms |= CreateFileAction

--- a/safeio/rules.go
+++ b/safeio/rules.go
@@ -1,6 +1,8 @@
 package safeio
 
-import "strings"
+import (
+	"strings"
+)
 
 // FSAccessRule knows how to allow or deny actions on a certain file path.
 type FSAccessRule interface {

--- a/safeio/rules.go
+++ b/safeio/rules.go
@@ -1,0 +1,62 @@
+package safeio
+
+import "strings"
+
+// FSAccessRule knows how to allow or deny actions on a certain file path.
+type FSAccessRule interface {
+	GetFSAccessEffect(path string, requested FSAction) (allowed FSAction, denied FSAction)
+}
+
+// FSAccessRuleset allows grouping rules together.
+type FSAccessRuleset struct {
+	Rules []FSAccessRule
+}
+
+// GetFSAccessEffect returns Deny if any of its rules returns Deny, otherwise
+// returns Allow if any of its rules returns Allow, otherwise returns None.
+func (s FSAccessRuleset) GetFSAccessEffect(path string, requested FSAction) (allowed FSAction, denied FSAction) {
+	for _, r := range s.Rules {
+		a, d := r.GetFSAccessEffect(path, requested)
+		allowed |= a
+		denied |= d
+	}
+	return
+}
+
+type PrefixFSAccessRule struct {
+	Prefix         string
+	AllowedActions FSAction
+	DeniedActions  FSAction
+}
+
+func (r PrefixFSAccessRule) GetFSAccessEffect(path string, actions FSAction) (allowed FSAction, denied FSAction) {
+	if !strings.HasPrefix(path, r.Prefix) {
+		// If the path does start with r.Prefix, there is no effect from this rule.
+		return 0, 0
+	}
+	return actions & r.AllowedActions, actions & r.DeniedActions
+}
+
+// MergeFSAccessRules returns an FSAccessRule representing all the rules passed
+// in.  It discards nil rules and flattens rulesets.
+func MergeFSAccessRules(rules ...FSAccessRule) FSAccessRule {
+	var mergedRules []FSAccessRule
+	for _, r := range rules {
+		if r == nil {
+			continue
+		}
+		if s, ok := r.(FSAccessRuleset); ok {
+			mergedRules = append(mergedRules, s.Rules...)
+		} else {
+			mergedRules = append(mergedRules, r)
+		}
+	}
+	switch len(mergedRules) {
+	case 0:
+		return nil
+	case 1:
+		return mergedRules[0]
+	default:
+		return FSAccessRuleset{Rules: mergedRules}
+	}
+}


### PR DESCRIPTION
This allows implementing access checking in safeio file access functions
An example of a simple prefix rule is implemented (PrefixFSAccessRule)
Also a rule to compose rules (FSAccessRuleset)

runtime.RuntimeContextDef can now take a FSAccessRule to specify what
access is allowed to the filesystem.