### PR TITLE
Support equality comparison of userdata

### DIFF
--- a/runtime/comp.go
+++ b/runtime/comp.go
@@ -96,8 +96,11 @@ func eq(t *Thread, x, y Value) (bool, error) {
 		if _, ok := y.TryTable(); !ok {
 			return false, nil
 		}
+	} else if _, ok := x.TryUserData(); ok {
+		if _, ok := y.TryUserData(); !ok {
+			return false, nil
+		}
 	} else {
-		// TODO: deal with UserData
 		return false, nil
 	}
 	res, err, ok := metabin(t, "__eq", x, y)

--- a/runtime/lua/comp.lua
+++ b/runtime/lua/comp.lua
@@ -27,3 +27,25 @@ print(pcall(function() return t <= false end))
 meta.__le = meta.__lt
 print(t <= false)
 --> =false
+
+do
+  local ud1 = testudata("foo")
+  local ud2 = testudata("bar")
+
+  print(ud1 == ud1)
+  --> =true
+  print(ud1 == ud2)
+  --> =false
+
+  local meta1 = {__eq=function(x, y) return true end}
+  local meta2 = {__eq=function(x, y) return false end}
+  debug.setmetatable(ud1, meta1)
+  debug.setmetatable(ud2, meta2)
+
+  print(ud1 == ud2)
+  --> =true
+  print(ud2 == ud1)
+  --> =false
+  --> =**release bar**
+  --> =**release foo**
+end


### PR DESCRIPTION
From the spec:

> __eq: the equal (==) operation. Behavior similar to the addition operation, except that Lua will try a metamethod only when the values being compared are either both tables or both full userdata and they are not primitively equal. The result of the call is always converted to a boolean.

So far, only "primitively equal" and "both tables" is implemented. This PR supports the "both full userdata" case.