### PR TITLE
Fix overflow on 32-bit archs

### DIFF
--- a/lib/stringlib/packformatreader.go
+++ b/lib/stringlib/packformatreader.go
@@ -39,7 +39,7 @@ func (p *packFormatReader) smallOptSize(defaultSize uint) (ok bool) {
 	return
 }
 
-const maxDecuplable = math.MaxUint64 / 10
+const maxDecuplable = math.MaxUint / 10
 
 func (p *packFormatReader) getOptSize() bool {
 	var (

--- a/runtime/value.go
+++ b/runtime/value.go
@@ -303,7 +303,7 @@ func (v Value) ToString() (string, bool) {
 	}
 	switch x := v.iface.(type) {
 	case int64:
-		return strconv.Itoa(int(v.AsInt())), true
+		return strconv.FormatInt(v.AsInt(), 10), true
 	case float64:
 		return strconv.FormatFloat(v.AsFloat(), 'g', -1, 64), true
 	case bool:


### PR DESCRIPTION
packFormatReader uses an `uint` for its option size, so `maxDecuplable` must not overflow `uint`. This happened on 32-bit archs and is fixed with this PR.