### PR TITLE
Forbid newindex for non-tables without __newindex

### DIFF
--- a/runtime/lib.go
+++ b/runtime/lib.go
@@ -83,8 +83,10 @@ func SetIndex(t *Thread, coll Value, idx Value, val Value) error {
 			if isTable {
 				// No need to call SetTableCheck
 				t.SetTable(tbl, idx, val)
+				return nil
 			}
-			return nil
+			return fmt.Errorf(
+				"attempt to index %s value without __newindex", coll.TypeName())
 		}
 		if _, ok := metaNewIndex.TryTable(); ok {
 			coll = metaNewIndex

--- a/runtime/lib_test.go
+++ b/runtime/lib_test.go
@@ -75,3 +75,18 @@ func TestRuntime_CompileAndLoadLuaChunkOrExp(t *testing.T) {
 		})
 	}
 }
+
+// TestSetIndexNoNewIndex tests setting new indices of values without
+// a __newindex metamethod.
+func TestSetIndexNoNewIndex(t *testing.T) {
+	r := New(os.Stdout)
+	intValue := IntValue(42)
+	meta := NewTable()
+	udValue := UserDataValue(NewUserData([]int{}, meta))
+	if err := SetIndex(r.MainThread(), intValue, intValue, intValue); err == nil {
+		t.Error("expected error indexing int value")
+	}
+	if err := SetIndex(r.MainThread(), udValue, intValue, intValue); err == nil {
+		t.Error("expected error indexing userdata value")
+	}
+}


### PR DESCRIPTION
Previously, a newindex event on a non-table without a suitable __newindex entry in its metatable would be silently ignored. This commit causes an error to be raised.

From the spec:
> Like with indexing, the metavalue for this event can be either a function, a table, or any value with an __newindex metavalue.

If none of these conditions applies, an error should be raised.