### PR TITLE
Do not use syscall for clock implementation on js platform

### DIFF
--- a/lib/oslib/clock.go
+++ b/lib/oslib/clock.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !js
+// +build !windows,!js
 
 package oslib
 

--- a/lib/oslib/clock_fallback.go
+++ b/lib/oslib/clock_fallback.go
@@ -1,5 +1,5 @@
-//go:build windows
-// +build windows
+//go:build windows || js
+// +build windows js
 
 package oslib
 


### PR DESCRIPTION
This is to resolve #110 