### PR TITLE
fix: fix iter over table with zero as key

### DIFF
--- a/runtime/hashtable.go
+++ b/runtime/hashtable.go
@@ -119,8 +119,8 @@ func (t *mixedTable) next(k Value) (next Value, v Value, ok bool) {
 		isInt = true
 	} else {
 		i, isInt = ToIntNoString(k)
-		if isInt && i == 0 {
-			return t.hashTable.next(IntValue(0))
+		if isInt && i <= 0 {
+			isInt = false
 		}
 	}
 	if isInt {

--- a/runtime/hashtable.go
+++ b/runtime/hashtable.go
@@ -119,6 +119,9 @@ func (t *mixedTable) next(k Value) (next Value, v Value, ok bool) {
 		isInt = true
 	} else {
 		i, isInt = ToIntNoString(k)
+		if isInt && i == 0 {
+			return t.hashTable.next(IntValue(0))
+		}
 	}
 	if isInt {
 		j, v, ok := t.array.next(i)

--- a/runtime/lua/tables.lua
+++ b/runtime/lua/tables.lua
@@ -89,3 +89,13 @@ do
     print(pcall(table.insert, t, 5))
     --> ~false\t.* haha
 end
+
+do
+    local t = {[0]=0, [1]=1, [2]=2}
+    local s = ""
+    for _, x in pairs(t) do
+        s = s..x
+    end
+    print(s)
+    --> =120
+end


### PR DESCRIPTION
I'm not sure is it the right fix, and i'm not sure i properly tested it.

But there is definitely a problem. A test i wrote in `table.lua` gets into infinite loop, because `next` calls are cycled.

Maybe it's worth adding this even in lua official testsuite? The order is unspecified, but it definitely must not gets into infinite loop.