### PR TITLE
Lua 5.5. __call chain limit

### DIFF
--- a/notes/lua5.5-features.md
+++ b/notes/lua5.5-features.md
@@ -104,10 +104,14 @@ Based on [Lua 5.5 README](https://www.lua.org/manual/5.5/readme.html) and [Incom
 - [N/A] **External strings** - Strings using memory not managed by Lua
   - Not applicable: Go manages string memory, not under our control
 
-- [ ] **`__call` metamethod chain limit** - Maximum 15 objects in chain
+- [x] **`__call` metamethod chain limit** - Maximum 15 objects in chain
   - Implementation: Add counter in function call evaluation during metamethod resolution
   - Prevents infinite recursion through chained `__call` metamethods
   - Complexity: **Low-Medium** - add depth tracking to call handling
+  - **Status**: ✅ Implemented in [runtime/lib.go](../runtime/lib.go) and [runtime/thread.go](../runtime/thread.go)
+  - Added `metacallChainDepth` field to Thread struct
+  - Modified `Call` and `Continue` functions to track and limit chain depth
+  - Test: [runtime/lua/metacall_chain_limit.lua](../runtime/lua/metacall_chain_limit.lua)
 
 - [ ] **Nil error objects replaced with message** - Error handling behavior change
   - Implementation: When nil becomes an error object, replace it with a string message

--- a/runtime/lib.go
+++ b/runtime/lib.go
@@ -25,6 +25,7 @@ func RawGet(t *Table, k Value) Value {
 }
 
 const maxIndexChainLength = 100
+const maxCallChainLength = 15 // Lua 5.5: limit __call metamethod chain
 
 // Index returns the item in a collection for the given key k, using the
 // '__index' metamethod if appropriate.
@@ -123,6 +124,15 @@ func Continue(t *Thread, f Value, next Cont) (Cont, error) {
 	if ok {
 		return callable.Continuation(t, next), nil
 	}
+	// Not callable, need to use __call metamethod
+	// Check if we've exceeded the chain limit (Lua 5.5)
+	if t.metacallChainDepth >= maxCallChainLength {
+		return nil, errors.New("'__call' chain too long")
+	}
+	// Increment chain depth before recursive call
+	t.metacallChainDepth++
+	defer func() { t.metacallChainDepth-- }()
+
 	cont, err, ok := metacont(t, f, "__call", next)
 	if !ok {
 		return nil, fmt.Errorf("attempt to call a %s value", f.CustomTypeName())
@@ -143,6 +153,15 @@ func Call(t *Thread, f Value, args []Value, next Cont) error {
 	if ok {
 		return t.call(callable, args, next)
 	}
+	// Not callable, need to use __call metamethod
+	// Check if we've exceeded the chain limit (Lua 5.5)
+	if t.metacallChainDepth >= maxCallChainLength {
+		return errors.New("'__call' chain too long")
+	}
+	// Increment chain depth before recursive call
+	t.metacallChainDepth++
+	defer func() { t.metacallChainDepth-- }()
+
 	err, ok := Metacall(t, f, "__call", append([]Value{f}, args...), next)
 	if ok {
 		return err

--- a/runtime/lua/metacall_chain_limit.lua
+++ b/runtime/lua/metacall_chain_limit.lua
@@ -1,0 +1,70 @@
+-- Test __call metamethod chain limit (Lua 5.5)
+-- A chain of __call metamethods can have at most 15 objects
+
+local function make_chain(depth)
+    if depth == 0 then
+        return function() return "success" end
+    end
+    return setmetatable({}, {__call = make_chain(depth - 1)})
+end
+
+-- Test chains within limit
+do
+    print(make_chain(1)())
+    --> =success
+end
+
+do
+    print(make_chain(5)())
+    --> =success
+end
+
+do
+    print(make_chain(10)())
+    --> =success
+end
+
+do
+    print(make_chain(14)())
+    --> =success
+end
+
+do
+    print(make_chain(15)())
+    --> =success
+end
+
+-- Test chains exceeding limit
+do
+    print(pcall(make_chain(16)))
+    --> ~^false\t.*'__call' chain too long
+end
+
+do
+    print(pcall(make_chain(20)))
+    --> ~^false\t.*'__call' chain too long
+end
+
+do
+    print(pcall(make_chain(100)))
+    --> ~^false\t.*'__call' chain too long
+end
+
+-- Test that normal recursive calls still work
+do
+    local function factorial(n)
+        if n <= 1 then return 1 end
+        return n * factorial(n - 1)
+    end
+    print(factorial(10))
+    --> =3628800
+end
+
+-- Test mixed scenario: chain with 3 objects
+do
+    local obj3 = function() return "reached function" end
+    local obj2 = setmetatable({}, {__call = obj3})
+    local obj1 = setmetatable({}, {__call = obj2})
+    print(obj1())
+    --> =reached function
+end

--- a/runtime/thread.go
+++ b/runtime/thread.go
@@ -52,6 +52,10 @@ type Thread struct {
 	// functions).
 	goFunctionCallDepth int
 
+	// Depth of __call metamethod chain (Lua 5.5).  This should not exceed
+	// maxCallChainLength to prevent infinite loops through chained __call metamethods.
+	metacallChainDepth int
+
 	DebugHooks
 
 	closeStack // Stack of pending to-be-closed values


### PR DESCRIPTION
__call chains are now limited to a length of 15 (previously unbounded)