### PR TITLE
WeakPool: GC pool based on weak.Pool

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,18 +6,81 @@ on:
 
 jobs:
 
-  build:
-    runs-on: ${{ matrix.os }}
+  # Full testing on Ubuntu with all build tags and pool combinations
+  test-ubuntu:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
+        pool:
+          - ''           # default (WeakPool on Go 1.24)
+          - 'clone'
+          - 'unsafe'
         build_tags:
-          - 'dummytagforwindows' # Non existent tag because windows shell drops empty arguments
+          - ''
           - 'noquotas'
           - 'nocontpool noregpool'
           - 'noquotas nocontpool noregpool'
-          - 'safepool'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.24'
+
+    - name: All tests
+      env:
+        GOLUA_POOL: ${{ matrix.pool }}
+      run: go test -tags "${{ matrix.build_tags }}" -coverprofile="coverage.txt" -covermode=atomic ./...
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v2
+      with:
+        files: ./coverage.txt
+        name: codecov-ubuntu-${{ matrix.pool || 'default' }}-${{ matrix.build_tags || 'notags' }}
+        verbose: true
+
+    - name: Build CLI
+      run: go build -tags "${{ matrix.build_tags }}"
+
+    - name: Check out Lua Test Suite 5.5
+      uses: actions/checkout@v4
+      with:
+        repository: arnodel/golua-tests
+        ref: golua-5.5
+        path: ./lua-test-suite
+
+    - name: Run Lua Test Suite
+      env:
+        GOLUA_POOL: ${{ matrix.pool }}
+      run: ../golua -u -e "_U=true" -e "_port=true" all.lua
+      working-directory: ./lua-test-suite
+
+  # Backward compatibility test with older Go (WeakPool excluded by build tag)
+  test-compat:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+
+    - name: All tests
+      run: go test -coverprofile="coverage.txt" -covermode=atomic ./...
+
+    - name: Build CLI
+      run: go build
+
+  # Testing on macOS and Windows with default pool and no build tags
+  test-other:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
         os:
-          - ubuntu-latest
           - macOS-latest
           - windows-latest
 
@@ -27,20 +90,20 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23
+        go-version: '1.24'
 
     - name: All tests
-      run: go test -tags "${{ matrix.build_tags }}" -coverprofile="coverage.txt" -covermode=atomic ./...
+      run: go test -coverprofile="coverage.txt" -covermode=atomic ./...
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2
       with:
         files: ./coverage.txt
-        name: codecov-all-tests
+        name: codecov-${{ matrix.os }}
         verbose: true
-    
+
     - name: Build CLI
-      run: go build -tags "${{ matrix.build_tags }}"
+      run: go build
 
     - name: Check out Lua Test Suite 5.5
       uses: actions/checkout@v4

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,5 @@
 github.com/arnodel/edit v0.0.0-20220202110212-dfc8d7a13890 h1:8ykH+u3lD7oYS1PfGD9YE7iv6K3IojBV71Bi9nxkE4k=
 github.com/arnodel/edit v0.0.0-20220202110212-dfc8d7a13890/go.mod h1:AcpttpuZBaL9xl8/CX+Em4fBTUbwIkJ66RiAsJlNrBk=
-github.com/arnodel/golua v0.0.0-20220121091306-866962c51982/go.mod h1:d8hJbh/X80uQdSGMu5HZ64LrIgPh1jQxcNhnAqggpWE=
 github.com/arnodel/strftime v0.1.6 h1:0hc0pUvk8KhEMXE+htyaOUV42zNcf/csIbjzEFCJqsw=
 github.com/arnodel/strftime v0.1.6/go.mod h1:5NbK5XqYK8QpRZpqKNt4OlxLtIB8cotkLk4KTKzJfWs=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=

--- a/runtime/internal/luagc/clonepool.go
+++ b/runtime/internal/luagc/clonepool.go
@@ -5,6 +5,10 @@ import (
 	"sync"
 )
 
+func init() {
+	RegisterPool("clone", func() Pool { return NewClonePool() })
+}
+
 //
 // Clone-based Pool implementation
 //
@@ -201,7 +205,7 @@ func (c *cloneEntry) clearFlag(flag wrStatusFlags) {
 
 type sortablePendingClones []cloneEntry
 
-var _ sort.Interface = sortableVals(nil)
+var _ sort.Interface = sortablePendingClones{}
 
 func (vs sortablePendingClones) Len() int {
 	return len(vs)

--- a/runtime/internal/luagc/defaultpool.go
+++ b/runtime/internal/luagc/defaultpool.go
@@ -1,8 +1,0 @@
-//go:build !safepool
-
-package luagc
-
-// NewDefaultPool returns a new WeakRefPool with an appropriate implementation.
-func NewDefaultPool() Pool {
-	return NewClonePool()
-}

--- a/runtime/internal/luagc/defaultpool_safepool.go
+++ b/runtime/internal/luagc/defaultpool_safepool.go
@@ -1,8 +1,0 @@
-//go:build safepool
-
-package luagc
-
-// NewPool returns a new Pool with an appropriate implementation.
-func NewDefaultPool() Pool {
-	return NewUnsafePool()
-}

--- a/runtime/internal/luagc/registry.go
+++ b/runtime/internal/luagc/registry.go
@@ -1,0 +1,54 @@
+package luagc
+
+import (
+	"os"
+	"sync"
+)
+
+var (
+	poolFactories = make(map[string]func() Pool)
+	registryMu    sync.RWMutex
+)
+
+// RegisterPool adds a pool factory to the registry.
+// This is typically called from init() functions.
+func RegisterPool(name string, factory func() Pool) {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	poolFactories[name] = factory
+}
+
+// DefaultPoolFactory returns a factory function that creates the best
+// available pool.
+//
+// The GOLUA_POOL environment variable can override the default selection
+// (useful for testing different pool implementations).
+//
+// Otherwise, it tries "weak" first (available on Go 1.24+), then falls back
+// to "clone".
+func DefaultPoolFactory() func() Pool {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	// Allow override via environment variable (mainly for testing)
+	if name := os.Getenv("GOLUA_POOL"); name != "" {
+		if factory, ok := poolFactories[name]; ok {
+			return factory
+		}
+	}
+	// Default: try weak first (Go 1.24+), fall back to clone
+	if factory, ok := poolFactories["weak"]; ok {
+		return factory
+	}
+	return poolFactories["clone"]
+}
+
+// PoolNames returns all registered pool names.
+func PoolNames() []string {
+	registryMu.RLock()
+	defer registryMu.RUnlock()
+	names := make([]string, 0, len(poolFactories))
+	for name := range poolFactories {
+		names = append(names, name)
+	}
+	return names
+}

--- a/runtime/internal/luagc/safepool.go
+++ b/runtime/internal/luagc/safepool.go
@@ -1,5 +1,9 @@
 package luagc
 
+func init() {
+	RegisterPool("safe", func() Pool { return NewSafePool() })
+}
+
 //
 // Safe Pool implementation
 //

--- a/runtime/internal/luagc/unsafepool.go
+++ b/runtime/internal/luagc/unsafepool.go
@@ -7,6 +7,10 @@ import (
 	"unsafe"
 )
 
+func init() {
+	RegisterPool("unsafe", func() Pool { return NewUnsafePool() })
+}
+
 //
 // Unsafe Pool implementation
 //

--- a/runtime/internal/luagc/weakref.go
+++ b/runtime/internal/luagc/weakref.go
@@ -1,7 +1,7 @@
 // Package luagc implements weak refs and weak ref pools to be used by the
 // Golua runtime.
 //
-// Two interfaces WeakRef and Pool are defined and the packages provides three
+// Two interfaces WeakRef and Pool are defined and the packages provides several
 // implementations of Pool.  The Golua runtime has a Pool instance that
 // it uses to help with finalizing of Lua values and making sure finalizers do
 // not run after the runtime has finished.
@@ -16,6 +16,9 @@
 // ClonePool also lets values be GCed when they are unreachable outside of the
 // pool and does so on any compliant Go implementation.  However it does not
 // support WeakRefs (i.e. Get(v) always returns nil).
+//
+// WeakPool (Go 1.24+, in the runtime package) uses Go's official weak.Pointer
+// API for proper weak references without unsafe tricks.
 package luagc
 
 // Value is the interface that must be implemented by values managed by a Pool.

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -48,6 +48,7 @@ type runtimeOptions struct {
 	regPoolSize       uint
 	regSetMaxAge      uint
 	runtimeContextDef *RuntimeContextDef
+	poolFactory       func() luagc.Pool
 }
 
 var defaultRuntimeOptions = runtimeOptions{
@@ -80,6 +81,15 @@ func WithRuntimeContext(def RuntimeContextDef) RuntimeOption {
 	}
 }
 
+// WithPoolFactory sets the factory function used to create weak reference
+// pools. Each isolated runtime context gets its own pool via this factory.
+// If not specified, the best available pool is chosen automatically.
+func WithPoolFactory(f func() luagc.Pool) RuntimeOption {
+	return func(rtOpts *runtimeOptions) {
+		rtOpts.poolFactory = f
+	}
+}
+
 // New returns a new pointer to a Runtime with the given stdout.
 func New(stdout io.Writer, opts ...RuntimeOption) *Runtime {
 	rtOpts := defaultRuntimeOptions
@@ -104,6 +114,11 @@ func New(stdout io.Writer, opts ...RuntimeOption) *Runtime {
 	gcThread.status = ThreadOK
 	r.gcThread = gcThread
 
+	if rtOpts.poolFactory != nil {
+		r.poolFactory = rtOpts.poolFactory
+	} else {
+		r.poolFactory = luagc.DefaultPoolFactory()
+	}
 	r.runtimeContextManager.initRoot()
 
 	if rtOpts.runtimeContextDef != nil {

--- a/runtime/runtimecontextmanager.go
+++ b/runtime/runtimecontextmanager.go
@@ -41,6 +41,7 @@ type runtimeContextManager struct {
 	nextCpuThreshold uint64
 
 	weakRefPool luagc.Pool
+	poolFactory func() luagc.Pool
 	gcPolicy    GCPolicy
 }
 
@@ -48,7 +49,7 @@ var _ RuntimeContext = (*runtimeContextManager)(nil)
 
 func (m *runtimeContextManager) initRoot() {
 	m.gcPolicy = IsolateGCPolicy
-	m.weakRefPool = luagc.NewDefaultPool()
+	m.weakRefPool = m.poolFactory()
 }
 
 func (m *runtimeContextManager) HardLimits() RuntimeResources {
@@ -129,7 +130,7 @@ func (m *runtimeContextManager) PushContext(ctx RuntimeContextDef) {
 	m.messageHandler = ctx.MessageHandler
 	m.parent = &parent
 	if ctx.GCPolicy == IsolateGCPolicy || ctx.HardLimits.Millis > 0 || ctx.HardLimits.Cpu > 0 || ctx.HardLimits.Memory > 0 {
-		m.weakRefPool = luagc.NewDefaultPool()
+		m.weakRefPool = m.poolFactory()
 		m.gcPolicy = IsolateGCPolicy
 	} else {
 		m.weakRefPool = parent.weakRefPool

--- a/runtime/runtimecontextmanager_noquotas.go
+++ b/runtime/runtimecontextmanager_noquotas.go
@@ -136,9 +136,6 @@ func (m *runtimeContextManager) LinearUnused(cpuFactor uint64) uint64 {
 func (m *runtimeContextManager) LinearRequire(cpuFactor uint64, amt uint64) {
 }
 
-func (m *runtimeContextManager) ResetQuota() {
-}
-
 func (m *runtimeContextManager) TerminateContext(format string, args ...interface{}) {
 	// I don't know if it should do it?
 	panic(ContextTerminationError{

--- a/runtime/runtimecontextmanager_noquotas.go
+++ b/runtime/runtimecontextmanager_noquotas.go
@@ -15,12 +15,13 @@ type runtimeContextManager struct {
 	messageHandler Callable
 	parent         *runtimeContextManager
 	weakRefPool    luagc.Pool
+	poolFactory    func() luagc.Pool
 }
 
 var _ RuntimeContext = (*runtimeContextManager)(nil)
 
 func (m *runtimeContextManager) initRoot() {
-	m.weakRefPool = luagc.NewDefaultPool()
+	m.weakRefPool = m.poolFactory()
 }
 
 func (m *runtimeContextManager) HardLimits() (r RuntimeResources) {

--- a/runtime/runtimecontextmanager_noquotas_test.go
+++ b/runtime/runtimecontextmanager_noquotas_test.go
@@ -38,7 +38,7 @@ func Test_runtimeContextManager_RuntimeContext(t *testing.T) {
 	}
 	m2 := m
 	m2.SetStopLevel(HardStop | SoftStop)
-	if m != m2 {
+	if m.Status() != m2.Status() {
 		t.Fail()
 	}
 }
@@ -59,15 +59,6 @@ func Test_runtimeContextManager_UnusedResources(t *testing.T) {
 		t.Fail()
 	}
 	if m.UnusedCPU() != 0 {
-		t.Fail()
-	}
-}
-
-func Test_runtimeContextManager_ResetQuota(t *testing.T) {
-	var m runtimeContextManager
-	var m1 = m
-	m.ResetQuota()
-	if m != m1 {
 		t.Fail()
 	}
 }

--- a/runtime/weakpool.go
+++ b/runtime/weakpool.go
@@ -1,0 +1,293 @@
+//go:build go1.24
+
+package runtime
+
+import (
+	"runtime"
+	"sort"
+	"sync"
+	"weak"
+
+	"github.com/arnodel/golua/runtime/internal/luagc"
+)
+
+func init() {
+	luagc.RegisterPool("weak", func() luagc.Pool { return NewWeakPool() })
+}
+
+// WeakPool is an implementation of luagc.Pool that uses Go 1.24's weak.Pointer
+// for proper weak references and runtime.AddCleanup for GC notifications.
+// Unlike UnsafePool, this implementation uses official Go APIs and will not
+// break if Go's GC implementation changes.
+//
+// This pool lives in the runtime package (rather than luagc) because it needs
+// to type-switch on concrete types (*Table, *UserData) to create weak pointers
+// and attach cleanups.
+type WeakPool struct {
+	mx              sync.Mutex
+	entries         map[luagc.Key]*weakEntry
+	pendingFinalize sortableWeakEntries
+	pendingRelease  sortableWeakEntries
+	lastMarkOrder   int
+}
+
+var _ luagc.Pool = &WeakPool{}
+
+// NewWeakPool returns a new *WeakPool ready to be used.
+func NewWeakPool() *WeakPool {
+	return &WeakPool{entries: make(map[luagc.Key]*weakEntry)}
+}
+
+// weakEntry holds tracking state for a value.
+type weakEntry struct {
+	wp      any             // weak.Pointer[Table] or weak.Pointer[UserData]
+	cleanup runtime.Cleanup // handle to cancel the cleanup
+	clone   luagc.Value     // Clone of the value for finalization
+	key     luagc.Key
+	pool    *WeakPool
+
+	markOrder int
+	flags     weakEntryFlags
+}
+
+type weakEntryFlags uint8
+
+const (
+	weFinalized weakEntryFlags = 1 << iota // The Lua finalizer no longer needs to run
+	weReleased                             // The value's resources no longer need to be released
+)
+
+func (e *weakEntry) hasFlag(flag weakEntryFlags) bool {
+	return e.flags&flag != 0
+}
+
+func (e *weakEntry) setFlag(flag weakEntryFlags) {
+	e.flags |= flag
+}
+
+func (e *weakEntry) clearFlag(flag weakEntryFlags) {
+	e.flags &= ^flag
+}
+
+// liveValue returns the referenced value if it's still alive via weak pointer.
+func (e *weakEntry) liveValue() luagc.Value {
+	switch wp := e.wp.(type) {
+	case weak.Pointer[Table]:
+		if t := wp.Value(); t != nil {
+			return t
+		}
+	case weak.Pointer[UserData]:
+		if u := wp.Value(); u != nil {
+			return u
+		}
+	}
+	return nil
+}
+
+// Get returns a WeakRef for v if possible.
+func (p *WeakPool) Get(v luagc.Value) luagc.WeakRef {
+	p.mx.Lock()
+	defer p.mx.Unlock()
+	entry := p.getOrCreateEntry(v)
+	return &weakPoolRef{entry: entry}
+}
+
+// Mark marks v for finalizing and/or releasing.
+func (p *WeakPool) Mark(v luagc.Value, flags luagc.MarkFlags) {
+	if flags == 0 {
+		return
+	}
+	p.mx.Lock()
+	defer p.mx.Unlock()
+	p.lastMarkOrder++
+	entry := p.getOrCreateEntry(v)
+	entry.clone = v.Clone() // Update clone to capture latest state (e.g., metatable)
+	entry.markOrder = p.lastMarkOrder
+	if flags&luagc.Finalize == 0 {
+		entry.setFlag(weFinalized)
+	} else {
+		entry.clearFlag(weFinalized)
+	}
+	if flags&luagc.Release == 0 {
+		entry.setFlag(weReleased)
+	} else {
+		entry.clearFlag(weReleased)
+	}
+}
+
+func (p *WeakPool) getOrCreateEntry(v luagc.Value) *weakEntry {
+	key := v.Key()
+	entry := p.entries[key]
+	if entry == nil {
+		entry = &weakEntry{
+			key:  key,
+			pool: p,
+		}
+
+		// Create weak pointer and attach cleanup based on concrete type.
+		switch x := v.(type) {
+		case *Table:
+			entry.wp = weak.Make(x)
+			entry.cleanup = runtime.AddCleanup(x, weakEntryCleanup, entry)
+		case *UserData:
+			entry.wp = weak.Make(x)
+			entry.cleanup = runtime.AddCleanup(x, weakEntryCleanup, entry)
+		}
+
+		p.entries[key] = entry
+	}
+	return entry
+}
+
+// weakEntryCleanup is called by Go's GC when a tracked value becomes
+// unreachable. It adds the value's clone to the appropriate pending lists.
+func weakEntryCleanup(entry *weakEntry) {
+	p := entry.pool
+	p.mx.Lock()
+	defer p.mx.Unlock()
+
+	ev := entryVal{v: entry.clone, e: entry}
+	if !entry.hasFlag(weFinalized) {
+		p.pendingFinalize = append(p.pendingFinalize, ev)
+	}
+	if !entry.hasFlag(weReleased) {
+		p.pendingRelease = append(p.pendingRelease, ev)
+	}
+	delete(p.entries, entry.key)
+}
+
+// ExtractPendingFinalize returns values needing Lua finalization.
+func (p *WeakPool) ExtractPendingFinalize() []luagc.Value {
+	p.mx.Lock()
+	pending := p.pendingFinalize
+	if pending == nil {
+		p.mx.Unlock()
+		return nil
+	}
+	p.pendingFinalize = nil
+	for _, ev := range pending {
+		ev.e.setFlag(weFinalized)
+	}
+	p.mx.Unlock()
+
+	sort.Sort(pending)
+	return pending.vals()
+}
+
+// ExtractPendingRelease returns values needing resource release.
+// Only returns values whose finalization is already done (weFinalized is set).
+func (p *WeakPool) ExtractPendingRelease() []luagc.Value {
+	p.mx.Lock()
+	if p.pendingRelease == nil {
+		p.mx.Unlock()
+		return nil
+	}
+	var ready, remaining sortableWeakEntries
+	for _, ev := range p.pendingRelease {
+		if ev.e.hasFlag(weFinalized) {
+			ev.e.setFlag(weReleased)
+			ready = append(ready, ev)
+		} else {
+			remaining = append(remaining, ev)
+		}
+	}
+	p.pendingRelease = remaining
+	p.mx.Unlock()
+
+	if ready == nil {
+		return nil
+	}
+	sort.Sort(ready)
+	return ready.vals()
+}
+
+// ExtractAllMarkedFinalize returns all values marked for finalizing.
+func (p *WeakPool) ExtractAllMarkedFinalize() []luagc.Value {
+	p.mx.Lock()
+	p.pendingFinalize = nil
+	var marked sortableWeakEntries
+	for _, entry := range p.entries {
+		if !entry.hasFlag(weFinalized) {
+			marked = append(marked, entryVal{
+				v: entry.clone,
+				e: entry,
+			})
+			entry.setFlag(weFinalized)
+			entry.cleanup.Stop()
+		}
+	}
+	p.mx.Unlock()
+
+	sort.Sort(marked)
+	return marked.vals()
+}
+
+// ExtractAllMarkedRelease returns all values marked for releasing.
+func (p *WeakPool) ExtractAllMarkedRelease() []luagc.Value {
+	p.mx.Lock()
+	marked := p.pendingRelease
+	for _, entry := range p.entries {
+		if !entry.hasFlag(weReleased) {
+			marked = append(marked, entryVal{
+				v: entry.clone,
+				e: entry,
+			})
+			entry.setFlag(weReleased)
+			entry.cleanup.Stop()
+		}
+	}
+	p.pendingRelease = nil
+	p.entries = nil
+	p.mx.Unlock()
+
+	sort.Sort(marked)
+	return marked.vals()
+}
+
+//
+// WeakRef implementation for WeakPool
+//
+
+type weakPoolRef struct {
+	entry *weakEntry
+}
+
+var _ luagc.WeakRef = &weakPoolRef{}
+
+// Value returns the value if still alive, otherwise nil.
+func (r *weakPoolRef) Value() luagc.Value {
+	return r.entry.liveValue()
+}
+
+//
+// Sorting helpers
+//
+
+type entryVal struct {
+	v luagc.Value
+	e *weakEntry
+}
+
+type sortableWeakEntries []entryVal
+
+var _ sort.Interface = sortableWeakEntries(nil)
+
+func (vs sortableWeakEntries) Len() int {
+	return len(vs)
+}
+
+func (vs sortableWeakEntries) Less(i, j int) bool {
+	return vs[i].e.markOrder > vs[j].e.markOrder
+}
+
+func (vs sortableWeakEntries) Swap(i, j int) {
+	vs[i], vs[j] = vs[j], vs[i]
+}
+
+func (vs sortableWeakEntries) vals() []luagc.Value {
+	vals := make([]luagc.Value, len(vs))
+	for i, v := range vs {
+		vals[i] = v.v
+	}
+	return vals
+}

--- a/runtime/weakpool_test.go
+++ b/runtime/weakpool_test.go
@@ -1,0 +1,337 @@
+//go:build go1.24
+
+package runtime
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/arnodel/golua/runtime/internal/luagc"
+)
+
+// simulateGC simulates the Go GC collecting the given entries by directly
+// invoking the cleanup function. This avoids relying on non-deterministic
+// real GC behavior for unit tests.
+func simulateGC(entries ...*weakEntry) {
+	for _, entry := range entries {
+		weakEntryCleanup(entry)
+	}
+}
+
+// getEntry returns the weakEntry for a value, for use in simulated GC.
+func getEntry(p *WeakPool, v luagc.Value) *weakEntry {
+	return p.entries[v.Key()]
+}
+
+func TestWeakPoolNoGC(t *testing.T) {
+	p := NewWeakPool()
+
+	t1 := NewTable()
+	t2 := NewTable()
+	u1 := NewUserData(1, nil)
+
+	p.Mark(t1, luagc.Finalize)
+	p.Mark(t2, luagc.Finalize|luagc.Release)
+	p.Mark(u1, luagc.Release)
+	// Re-mark t1 (should update, not duplicate)
+	p.Mark(t1, luagc.Finalize)
+
+	// No GC has happened, so nothing should be pending.
+	if n := len(p.ExtractPendingFinalize()); n != 0 {
+		t.Fatalf("Expected no pending finalize, got %d", n)
+	}
+	if n := len(p.ExtractPendingRelease()); n != 0 {
+		t.Fatalf("Expected no pending release, got %d", n)
+	}
+
+	// ExtractAllMarkedFinalize should return t1 and t2 (both marked for finalize).
+	mf := p.ExtractAllMarkedFinalize()
+	if len(mf) != 2 {
+		t.Fatalf("Expected 2 marked finalize, got %d", len(mf))
+	}
+	// Second call should return nothing.
+	if n := len(p.ExtractAllMarkedFinalize()); n != 0 {
+		t.Fatalf("Expected no marked finalize on second call, got %d", n)
+	}
+
+	// ExtractAllMarkedRelease should return t2 and u1 (both marked for release).
+	mr := p.ExtractAllMarkedRelease()
+	if len(mr) != 2 {
+		t.Fatalf("Expected 2 marked release, got %d", len(mr))
+	}
+	// Second call should return nothing.
+	if n := len(p.ExtractAllMarkedRelease()); n != 0 {
+		t.Fatalf("Expected no marked release on second call, got %d", n)
+	}
+}
+
+func TestWeakPoolFinalizeOnly(t *testing.T) {
+	p := NewWeakPool()
+
+	t1 := NewTable()
+	t2 := NewTable()
+
+	p.Mark(t1, luagc.Finalize)
+	p.Mark(t2, luagc.Finalize)
+
+	e1 := getEntry(p, t1)
+	e2 := getEntry(p, t2)
+
+	// Simulate GC collecting both values.
+	simulateGC(e2, e1) // Reverse order to test sorting
+
+	pf := p.ExtractPendingFinalize()
+	if len(pf) != 2 {
+		t.Fatalf("Expected 2 pending finalize, got %d", len(pf))
+	}
+
+	// Should be sorted by reverse mark order (t2 before t1).
+	if pf[0].Key() != t2.Key() {
+		t.Fatal("Expected t2 first in pending finalize (reverse mark order)")
+	}
+	if pf[1].Key() != t1.Key() {
+		t.Fatal("Expected t1 second in pending finalize (reverse mark order)")
+	}
+
+	// No pending release (not marked for it).
+	pr := p.ExtractPendingRelease()
+	if len(pr) != 0 {
+		t.Fatalf("Expected 0 pending release, got %d", len(pr))
+	}
+}
+
+func TestWeakPoolReleaseOnly(t *testing.T) {
+	p := NewWeakPool()
+
+	u1 := NewUserData(1, nil)
+	u2 := NewUserData(2, nil)
+
+	p.Mark(u1, luagc.Release)
+	p.Mark(u2, luagc.Release)
+
+	e1 := getEntry(p, u1)
+	e2 := getEntry(p, u2)
+
+	simulateGC(e1, e2)
+
+	// Nothing pending for finalize (not marked).
+	pf := p.ExtractPendingFinalize()
+	if len(pf) != 0 {
+		t.Fatalf("Expected 0 pending finalize, got %d", len(pf))
+	}
+
+	// Both should be immediately available for release (weFinalized is
+	// already set because they were not marked for finalization).
+	pr := p.ExtractPendingRelease()
+	if len(pr) != 2 {
+		t.Fatalf("Expected 2 pending release, got %d", len(pr))
+	}
+}
+
+func TestWeakPoolFinalizeBeforeRelease(t *testing.T) {
+	// Values marked for both Finalize and Release should only be released
+	// after finalization has been extracted.
+	p := NewWeakPool()
+
+	tbl := NewTable()
+	p.Mark(tbl, luagc.Finalize|luagc.Release)
+	entry := getEntry(p, tbl)
+
+	simulateGC(entry)
+
+	// Release should not yet be available (finalization hasn't been extracted).
+	pr := p.ExtractPendingRelease()
+	if len(pr) != 0 {
+		t.Fatalf("Expected 0 pending release before finalize, got %d", len(pr))
+	}
+
+	// Extract finalization.
+	pf := p.ExtractPendingFinalize()
+	if len(pf) != 1 {
+		t.Fatalf("Expected 1 pending finalize, got %d", len(pf))
+	}
+
+	// Now release should be available.
+	pr = p.ExtractPendingRelease()
+	if len(pr) != 1 {
+		t.Fatalf("Expected 1 pending release after finalize, got %d", len(pr))
+	}
+
+	// Both lists should now be empty.
+	if n := len(p.ExtractPendingFinalize()); n != 0 {
+		t.Fatalf("Expected no more pending finalize, got %d", n)
+	}
+	if n := len(p.ExtractPendingRelease()); n != 0 {
+		t.Fatalf("Expected no more pending release, got %d", n)
+	}
+}
+
+func TestWeakPoolRemarkChangesFlags(t *testing.T) {
+	p := NewWeakPool()
+
+	tbl := NewTable()
+
+	// First mark for finalize only.
+	p.Mark(tbl, luagc.Finalize)
+	entry := getEntry(p, tbl)
+	if !entry.hasFlag(weReleased) {
+		t.Fatal("Expected weReleased to be set (not marked for release)")
+	}
+	if entry.hasFlag(weFinalized) {
+		t.Fatal("Expected weFinalized to be clear (marked for finalize)")
+	}
+
+	// Re-mark for release only.
+	p.Mark(tbl, luagc.Release)
+	if entry.hasFlag(weReleased) {
+		t.Fatal("Expected weReleased to be clear (marked for release)")
+	}
+	if !entry.hasFlag(weFinalized) {
+		t.Fatal("Expected weFinalized to be set (not marked for finalize)")
+	}
+}
+
+func TestWeakPoolExtractAllMarkedFinalize(t *testing.T) {
+	p := NewWeakPool()
+
+	t1 := NewTable()
+	t2 := NewTable()
+	u1 := NewUserData(1, nil)
+
+	p.Mark(t1, luagc.Finalize)
+	p.Mark(t2, luagc.Finalize|luagc.Release)
+	p.Mark(u1, luagc.Release) // Not marked for finalize
+
+	// Simulate GC for t1 only (it goes to pendingFinalize).
+	e1 := getEntry(p, t1)
+	simulateGC(e1)
+
+	// ExtractAllMarkedFinalize should return t2 (still in entries, not yet
+	// finalized). t1 is already in pendingFinalize but that list is cleared.
+	// u1 is already flagged as finalized (Release-only).
+	mf := p.ExtractAllMarkedFinalize()
+	if len(mf) != 1 {
+		t.Fatalf("Expected 1 marked finalize, got %d", len(mf))
+	}
+	if mf[0].Key() != t2.Key() {
+		t.Fatal("Expected t2 in marked finalize")
+	}
+}
+
+func TestWeakPoolExtractAllMarkedRelease(t *testing.T) {
+	p := NewWeakPool()
+
+	t1 := NewTable()
+	u1 := NewUserData(1, nil)
+
+	p.Mark(t1, luagc.Finalize|luagc.Release)
+	p.Mark(u1, luagc.Release)
+
+	// Simulate GC for u1 (goes to pendingRelease since it's release-only).
+	eu1 := getEntry(p, u1)
+	simulateGC(eu1)
+
+	// ExtractAllMarkedRelease should return both t1 (from entries) and u1
+	// (from pendingRelease).
+	mr := p.ExtractAllMarkedRelease()
+	if len(mr) != 2 {
+		t.Fatalf("Expected 2 marked release, got %d", len(mr))
+	}
+}
+
+func TestWeakPoolMultipleValues(t *testing.T) {
+	const n = 20
+	p := NewWeakPool()
+
+	tables := make([]*Table, n)
+	entries := make([]*weakEntry, n)
+
+	for i := range tables {
+		tables[i] = NewTable()
+		p.Mark(tables[i], luagc.Finalize)
+		entries[i] = getEntry(p, tables[i])
+	}
+
+	// Simulate GC for all in reverse order.
+	for i := n - 1; i >= 0; i-- {
+		simulateGC(entries[i])
+	}
+
+	pf := p.ExtractPendingFinalize()
+	if len(pf) != n {
+		t.Fatalf("Expected %d pending finalize, got %d", n, len(pf))
+	}
+
+	// Should be sorted by reverse mark order (last marked first).
+	for i, v := range pf {
+		expected := n - 1 - i
+		if v.Key() != tables[expected].Key() {
+			t.Fatalf("At position %d: expected table %d", i, expected)
+		}
+	}
+}
+
+func TestWeakPoolGet(t *testing.T) {
+	p := NewWeakPool()
+
+	tbl := NewTable()
+	p.Mark(tbl, luagc.Finalize)
+
+	ref := p.Get(tbl)
+	if ref == nil {
+		t.Fatal("Expected non-nil WeakRef")
+	}
+
+	// While the value is alive, Value() should return it.
+	v := ref.Value()
+	if v == nil {
+		t.Fatal("Expected WeakRef.Value() to be non-nil for live value")
+	}
+}
+
+func TestWeakPoolRealGC(t *testing.T) {
+	// This test uses real GC to verify end-to-end behavior.
+	// It's less deterministic but validates the AddCleanup integration.
+	p := NewWeakPool()
+
+	// Create values in a function scope so they become unreachable.
+	func() {
+		tbl := NewTable()
+		p.Mark(tbl, luagc.Finalize)
+	}()
+
+	// Force GC and give cleanups time to run.
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+	}
+
+	pf := p.ExtractPendingFinalize()
+	if len(pf) != 1 {
+		t.Fatalf("Expected 1 pending finalize after real GC, got %d", len(pf))
+	}
+}
+
+func TestWeakPoolRealGCFinalizeAndRelease(t *testing.T) {
+	p := NewWeakPool()
+
+	func() {
+		ud := NewUserData(42, nil)
+		p.Mark(ud, luagc.Finalize|luagc.Release)
+	}()
+
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+	}
+
+	// Should have pending finalize.
+	pf := p.ExtractPendingFinalize()
+	if len(pf) != 1 {
+		t.Fatalf("Expected 1 pending finalize, got %d", len(pf))
+	}
+
+	// After extracting finalize, release should be available.
+	pr := p.ExtractPendingRelease()
+	if len(pr) != 1 {
+		t.Fatalf("Expected 1 pending release, got %d", len(pr))
+	}
+}


### PR DESCRIPTION
Since go 1.24 weak pointers are available via the `weak` stdlib package.  This means we can now have a GC pool with similar characteristics as `luagc.UnsafePool` but implemented safely in Go.  We get further simplifications by using `runtime.AddCleanup` instead of `runtime.SetFinalizer`.

We could remove all other `luagc.Pool` implementations in the future I think but for now that would mean we require go1.24 (which is a big just from go1.18 currently)