### PR TITLE
Lua5.5 table conveniance methods

### DIFF
--- a/runtime/table.go
+++ b/runtime/table.go
@@ -107,7 +107,29 @@ func (t *Table) Next(k Value) (next Value, val Value, ok bool) {
 //   - Keys stored only in the map part do not affect the result.
 //   - An empty table always returns false.
 func (t *Table) IsArray() bool {
-	return t.mixedTable.array.itemCount() > 0
+	// this does not work because of the way
+	// the allocation is optimized
+	// ----------------------------------
+	// return t.mixedTable.array.itemCount() > 0
+	// ----------------------------------
+	// we resort to a full/partial table scan
+	var _k Value = NilValue
+	var _ok bool = true
+
+	for _ok {
+		_k, _, _ok = t.Next(_k)
+		if !_ok || _k.IsNil() {
+			break
+		}
+		// only if keys are integer numbers
+		if _k.TypeName() == "number" {
+			switch _k.iface.(type) {
+			case int64:
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // IsMap reports whether t contains a map part.
@@ -116,8 +138,28 @@ func (t *Table) IsArray() bool {
 //   - Values stored only in the array part do not affect the result.
 //   - An empty table always returns false.
 func (t *Table) IsMap() bool {
-	for _, s := range t.mixedTable.hashTable.slots {
-		if !s.isEmpty() {
+	// this does not work because of the way
+	// the allocation is optimized
+	// ----------------------------------
+	// for _, s := range t.mixedTable.hashTable.slots {
+	//		if !s.isEmpty() {
+	//			return true
+	//		}
+	//	}
+	//	return false
+	// ----------------------------------
+	// we resort to a full/partial table scan
+	var _k Value = NilValue
+	var _ok bool = true
+
+	for _ok {
+		_k, _, _ok = t.Next(_k)
+		if !_ok || _k.IsNil() {
+			break
+		}
+		switch _k.iface.(type) {
+		case int64:
+		default:
 			return true
 		}
 	}
@@ -148,17 +190,25 @@ func (t *Table) IsMapOnly() bool {
 	return !t.IsArray() && t.IsMap()
 }
 
-// MapKeys returns the keys stored in the map part of t.
+// MapKeys returns the keys stored in the conceptual map of t.
 //
-//   - Only keys stored in the map part are included.
-//   - Keys stored in the array part are never included.
-//   - If the map part of t is empty, MapKeys returns an empty slice.
-//   - The order of the returned keys is unspecified and should not be relied upon.
+// - Only non-integer keys stored in the map part are considered.
+// - The order of the returned keys is unspecified and should not be relied upon.
 func (t *Table) MapKeys() []Value {
+	// we resort to a full/partial table scan
 	keys := make([]Value, 0)
-	for _, s := range t.mixedTable.hashTable.slots {
-		if !s.isEmpty() {
-			keys = append(keys, s.key)
+	var _k Value = NilValue
+	var _ok bool = true
+
+	for _ok {
+		_k, _, _ok = t.Next(_k)
+		if !_ok || _k.IsNil() {
+			break
+		}
+		switch _k.iface.(type) {
+		case int64:
+		default:
+			keys = append(keys, _k)
 		}
 	}
 	return keys
@@ -166,59 +216,60 @@ func (t *Table) MapKeys() []Value {
 
 // MapGoKeys returns the string keys stored in the map part of t.
 //
-// - Only keys stored in the map part are considered.
-// - Only keys that can be converted to a Go string are included.
-// - Map keys that cannot be converted to a Go string are silently ignored.
-// - Keys stored in the array part are never included.
-// - If the map part of t contains no string keys, MapGoKeys returns an empty slice.
+// - Only non-integer keys stored in the map part are considered.
 // - The order of the returned keys is unspecified and should not be relied upon.
-func (t *Table) MapGoKeys() []string {
-	keys := make([]string, 0)
-	for _, s := range t.mixedTable.hashTable.slots {
-		if s.isEmpty() {
-			continue
+func (t *Table) MapGoKeys() []any {
+	vkeys := t.MapKeys()
+	keys := make([]any, 0)
+
+	for _, _k := range vkeys {
+		switch _k.iface.(type) {
+		case int64:
+		default:
+			keys = append(keys, _k.iface)
 		}
-		// only stringified key make sense
-		str, ok := s.key.ToString()
-		if !ok {
-			// we silently ignore non-string keys
-			continue
-		}
-		keys = append(keys, str)
 	}
+
 	return keys
 }
 
 // ArrayKeys returns the keys stored in the array part of t.
 //
-// - Only keys corresponding to non-nil values in the array part are included.
-// - Keys stored in the map part are never included.
-// - If the array part of t is empty, ArrayKeys returns an empty slice.
+// - Only keys corresponding to int values are included.
 // - The order of the returned keys is unspecified and should not be relied upon.
 func (t *Table) ArrayKeys() []Value {
+	// we resort to a full/partial table scan
 	keys := make([]Value, 0)
-	for i, s := range t.mixedTable.array.values {
-		if s.IsNil() {
-			continue
+	var _k Value = NilValue
+	var _ok bool = true
+
+	for _ok {
+		_k, _, _ok = t.Next(_k)
+		if !_ok || _k.IsNil() {
+			break
 		}
-		keys = append(keys, IntValue(int64(i)))
+		switch _k.iface.(type) {
+		case int64:
+			keys = append(keys, _k)
+		}
 	}
 	return keys
 }
 
 // ArrayGoKeys returns the integer keys stored in the array part of t.
 //
-// - Only keys corresponding to non-nil values in the array part are included.
-// - Keys stored in the map part are never included.
-// - If the array part of t is empty, ArrayGoKeys returns an empty slice.
+// - Only integer keys are included.
 // - The order of the returned keys is unspecified and should not be relied upon.
 func (t *Table) ArrayGoKeys() []int64 {
+	vkeys := t.ArrayKeys()
 	keys := make([]int64, 0)
-	for i, s := range t.mixedTable.array.values {
-		if s.IsNil() {
-			continue
+
+	for _, _k := range vkeys {
+		switch _k.iface.(type) {
+		case int64:
+			keys = append(keys, _k.AsInt())
 		}
-		keys = append(keys, int64(i))
 	}
+
 	return keys
 }

--- a/runtime/table.go
+++ b/runtime/table.go
@@ -100,3 +100,125 @@ func (t *Table) Len() int64 {
 func (t *Table) Next(k Value) (next Value, val Value, ok bool) {
 	return t.mixedTable.next(k)
 }
+
+// IsArray reports whether t contains an array part.
+//
+//   - IsArray returns true if and only if the array part of t contains at least one value.
+//   - Keys stored only in the map part do not affect the result.
+//   - An empty table always returns false.
+func (t *Table) IsArray() bool {
+	return t.mixedTable.array.itemCount() > 0
+}
+
+// IsMap reports whether t contains a map part.
+//
+//   - IsMap returns true if and only if the map part of t contains at least one key-value pair.
+//   - Values stored only in the array part do not affect the result.
+//   - An empty table always returns false.
+func (t *Table) IsMap() bool {
+	for _, s := range t.mixedTable.hashTable.slots {
+		if !s.isEmpty() {
+			return true
+		}
+	}
+	return false
+}
+
+// IsMixed reports whether t contains both an array part and a map part.
+//
+//   - IsMixed returns true if and only if both IsArray and IsMap return true.
+//   - An empty table always returns false.
+func (t *Table) IsMixed() bool {
+	return t.IsArray() && t.IsMap()
+}
+
+// IsArrayOnly reports whether t contains an array part and no map part.
+//
+//   - IsArrayOnly returns true if and only if IsArray returns true and IsMap returns false.
+//   - An empty table always returns false.
+func (t *Table) IsArrayOnly() bool {
+	return t.IsArray() && !t.IsMap()
+}
+
+// IsMapOnly reports whether t contains a map part and no array part.
+//
+//   - IsMapOnly returns true if and only if IsArray returns false and IsMap returns true.
+//   - An empty table always returns false.
+func (t *Table) IsMapOnly() bool {
+	return !t.IsArray() && t.IsMap()
+}
+
+// MapKeys returns the keys stored in the map part of t.
+//
+//   - Only keys stored in the map part are included.
+//   - Keys stored in the array part are never included.
+//   - If the map part of t is empty, MapKeys returns an empty slice.
+//   - The order of the returned keys is unspecified and should not be relied upon.
+func (t *Table) MapKeys() []Value {
+	keys := make([]Value, 0)
+	for _, s := range t.mixedTable.hashTable.slots {
+		if !s.isEmpty() {
+			keys = append(keys, s.key)
+		}
+	}
+	return keys
+}
+
+// MapGoKeys returns the string keys stored in the map part of t.
+//
+// - Only keys stored in the map part are considered.
+// - Only keys that can be converted to a Go string are included.
+// - Map keys that cannot be converted to a Go string are silently ignored.
+// - Keys stored in the array part are never included.
+// - If the map part of t contains no string keys, MapGoKeys returns an empty slice.
+// - The order of the returned keys is unspecified and should not be relied upon.
+func (t *Table) MapGoKeys() []string {
+	keys := make([]string, 0)
+	for _, s := range t.mixedTable.hashTable.slots {
+		if s.isEmpty() {
+			continue
+		}
+		// only stringified key make sense
+		str, ok := s.key.ToString()
+		if !ok {
+			// we silently ignore non-string keys
+			continue
+		}
+		keys = append(keys, str)
+	}
+	return keys
+}
+
+// ArrayKeys returns the keys stored in the array part of t.
+//
+// - Only keys corresponding to non-nil values in the array part are included.
+// - Keys stored in the map part are never included.
+// - If the array part of t is empty, ArrayKeys returns an empty slice.
+// - The order of the returned keys is unspecified and should not be relied upon.
+func (t *Table) ArrayKeys() []Value {
+	keys := make([]Value, 0)
+	for i, s := range t.mixedTable.array.values {
+		if s.IsNil() {
+			continue
+		}
+		keys = append(keys, IntValue(int64(i)))
+	}
+	return keys
+}
+
+// ArrayGoKeys returns the integer keys stored in the array part of t.
+//
+// - Only keys corresponding to non-nil values in the array part are included.
+// - Keys stored in the map part are never included.
+// - If the array part of t is empty, ArrayGoKeys returns an empty slice.
+// - The order of the returned keys is unspecified and should not be relied upon.
+func (t *Table) ArrayGoKeys() []int64 {
+	keys := make([]int64, 0)
+	for i, s := range t.mixedTable.array.values {
+		if s.IsNil() {
+			continue
+		}
+		keys = append(keys, int64(i))
+	}
+	return keys
+}

--- a/runtime/table_test.go
+++ b/runtime/table_test.go
@@ -53,3 +53,85 @@ func TestTable_Next(t *testing.T) {
 		t.Errorf("Expected (1, x) and (2, y) to be the items, got (%v, %v) and (%v, %v)", k1, v1, k2, v2)
 	}
 }
+
+func TestTable_IsArray(t *testing.T) {
+	tbl := NewTable()
+	tbl.Set(v(1), v("x"))
+	tbl.Set(v(2), v("y"))
+
+	ok1 := tbl.IsArray()
+	if !ok1 {
+		t.Fatal("expected that array part has values")
+	}
+
+	tbl = NewTable()
+	tbl.Set(v("1"), v("x"))
+	tbl.Set(v("2"), v("y"))
+
+	ok2 := !tbl.IsArray()
+	if !ok2 {
+		t.Fatal("expected that array part has no values")
+	}
+}
+
+func TestTable_IsArrayOnly(t *testing.T) {
+	tbl := NewTable()
+	tbl.Set(v(1), v("x"))
+	tbl.Set(v(2), v("y"))
+
+	ok1 := tbl.IsArrayOnly()
+	if !ok1 {
+		t.Fatal("expected that only array part has values")
+	}
+
+	tbl = NewTable()
+	tbl.Set(v("1"), v("x"))
+	tbl.Set(v("2"), v("y"))
+
+	ok2 := !tbl.IsArrayOnly()
+	if !ok2 {
+		t.Fatal("expected that array part has no values")
+	}
+}
+
+func TestTable_IsMap(t *testing.T) {
+	tbl := NewTable()
+	tbl.Set(v(1), v("x"))
+	tbl.Set(v(2), v("y"))
+
+	ok1 := !tbl.IsMap()
+	if !ok1 {
+		t.Fatal("expected that map part has no values")
+	}
+
+	tbl = NewTable()
+	tbl.Set(v("1"), v("x"))
+	tbl.Set(v("2"), v("y"))
+
+	ok2 := tbl.IsMap()
+	if !ok2 {
+		t.Fatal("expected that map part has values")
+	}
+}
+
+func TestTable_IsMapOnly(t *testing.T) {
+	tbl := NewTable()
+	tbl.Set(v(1), v("x"))
+	tbl.Set(v(2), v("y"))
+	tbl.Set(v("1"), v("x"))
+	tbl.Set(v("2"), v("y"))
+
+	ok1 := !tbl.IsMapOnly()
+	if !ok1 {
+		t.Fatal("expected that map part has no values")
+	}
+
+	tbl = NewTable()
+	tbl.Set(v("1"), v("x"))
+	tbl.Set(v("2"), v("y"))
+
+	ok2 := tbl.IsMapOnly()
+	if !ok2 {
+		t.Fatal("expected that map part has values")
+	}
+}


### PR DESCRIPTION
had to delve into your table optimizations
added first set of tests

```
=== RUN   TestTable_IsArray
--- PASS: TestTable_IsArray (0.00s)
=== RUN   TestTable_IsArrayOnly
--- PASS: TestTable_IsArrayOnly (0.00s)
=== RUN   TestTable_IsMap
--- PASS: TestTable_IsMap (0.00s)
=== RUN   TestTable_IsMapOnly
--- PASS: TestTable_IsMapOnly (0.00s)
```